### PR TITLE
Add visual image support for members, chores, and rewards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "vite": "^7.1.7"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/context/FamboardContext.jsx
+++ b/src/context/FamboardContext.jsx
@@ -5,9 +5,24 @@ const STORAGE_KEY = 'famboard-state-v1'
 const defaultData = {
   theme: 'light',
   familyMembers: [
-    { id: 'member-1', name: 'Alex', points: 0 },
-    { id: 'member-2', name: 'Jamie', points: 0 },
-    { id: 'member-3', name: 'Riley', points: 0 },
+    {
+      id: 'member-1',
+      name: 'Alex',
+      points: 0,
+      imageUrl: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=160&q=80',
+    },
+    {
+      id: 'member-2',
+      name: 'Jamie',
+      points: 0,
+      imageUrl: 'https://images.unsplash.com/photo-1520719627573-5e2c1a6610f0?auto=format&fit=crop&w=160&q=80',
+    },
+    {
+      id: 'member-3',
+      name: 'Riley',
+      points: 0,
+      imageUrl: 'https://images.unsplash.com/photo-1445633883498-7f9922d37a3d?auto=format&fit=crop&w=160&q=80',
+    },
   ],
   chores: [
     {
@@ -18,6 +33,7 @@ const defaultData = {
       points: 10,
       completed: false,
       completedAt: null,
+      imageUrl: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=200&q=80',
     },
     {
       id: 'chore-2',
@@ -27,6 +43,7 @@ const defaultData = {
       points: 8,
       completed: false,
       completedAt: null,
+      imageUrl: 'https://images.unsplash.com/photo-1543852786-1cf6624b9987?auto=format&fit=crop&w=200&q=80',
     },
     {
       id: 'chore-3',
@@ -36,6 +53,7 @@ const defaultData = {
       points: 12,
       completed: false,
       completedAt: null,
+      imageUrl: 'https://images.unsplash.com/photo-1527515637462-cff94eecc1ac?auto=format&fit=crop&w=200&q=80',
     },
   ],
   rewards: [
@@ -44,18 +62,21 @@ const defaultData = {
       title: 'Pick the family movie',
       description: 'Choose the movie for Friday movie night.',
       cost: 30,
+      imageUrl: 'https://images.unsplash.com/photo-1489599849927-2ee91cede3ba?auto=format&fit=crop&w=200&q=80',
     },
     {
       id: 'reward-2',
       title: 'Extra 30 minutes of screen time',
       description: 'Enjoy more tablet or console time.',
       cost: 45,
+      imageUrl: 'https://images.unsplash.com/photo-1486578077620-8a022ddd481f?auto=format&fit=crop&w=200&q=80',
     },
     {
       id: 'reward-3',
       title: 'Choose dinner',
       description: 'Decide what the family will have for dinner.',
       cost: 60,
+      imageUrl: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=200&q=80',
     },
   ],
 }
@@ -104,12 +125,17 @@ export function FamboardProvider({ children }) {
           ...prev,
           theme,
         })),
-      addFamilyMember: (name) =>
+      addFamilyMember: (payload) =>
         setState((prev) => ({
           ...prev,
           familyMembers: [
             ...prev.familyMembers,
-            { id: createId('member'), name, points: 0 },
+            {
+              id: createId('member'),
+              name: payload.name,
+              points: 0,
+              imageUrl: payload.imageUrl ?? '',
+            },
           ],
         })),
       updateFamilyMember: (id, updates) =>
@@ -140,6 +166,7 @@ export function FamboardProvider({ children }) {
               points: Math.max(Number(payload.points) || 0, 0),
               completed: false,
               completedAt: null,
+              imageUrl: payload.imageUrl ?? '',
             },
           ],
         })),
@@ -162,6 +189,7 @@ export function FamboardProvider({ children }) {
                   ...updates,
                   assignedTo: nextAssigned ?? null,
                   points: nextPoints,
+                  imageUrl: updates.imageUrl !== undefined ? updates.imageUrl : chore.imageUrl,
                 }
               : chore,
           )
@@ -264,6 +292,7 @@ export function FamboardProvider({ children }) {
               title: payload.title,
               description: payload.description,
               cost: Math.max(Number(payload.cost) || 0, 0),
+              imageUrl: payload.imageUrl ?? '',
             },
           ],
         })),
@@ -279,6 +308,7 @@ export function FamboardProvider({ children }) {
                     updates.cost !== undefined
                       ? Math.max(Number(updates.cost) || 0, 0)
                       : reward.cost,
+                  imageUrl: updates.imageUrl !== undefined ? updates.imageUrl : reward.imageUrl,
                 }
               : reward,
           ),

--- a/src/pages/ChoresScreen.jsx
+++ b/src/pages/ChoresScreen.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useFamboard } from '../context/FamboardContext.jsx'
 import { launchConfetti } from '../utils/confetti.js'
 
@@ -9,6 +10,7 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
     description: chore.description,
     assignedTo: chore.assignedTo ?? '',
     points: chore.points,
+    imageUrl: chore.imageUrl ?? '',
   })
 
   useEffect(() => {
@@ -17,6 +19,7 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
       description: chore.description,
       assignedTo: chore.assignedTo ?? '',
       points: chore.points,
+      imageUrl: chore.imageUrl ?? '',
     })
   }, [chore])
 
@@ -29,6 +32,7 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
       description: form.description.trim(),
       assignedTo: form.assignedTo || null,
       points: Number(form.points) || 0,
+      imageUrl: form.imageUrl.trim(),
     })
     setIsEditing(false)
   }
@@ -41,6 +45,18 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
     <div className="rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-sm transition hover:border-famboard-primary/60 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900/80">
       {isEditing ? (
         <form className="space-y-3" onSubmit={handleSubmit}>
+          <div className="flex items-center gap-3">
+            <div className="h-20 w-20 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+              {form.imageUrl ? (
+                <img src={form.imageUrl} alt={form.title} className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-3xl">🧹</div>
+              )}
+            </div>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Add a picture so little helpers recognize the task in a snap.
+            </p>
+          </div>
           <div className="space-y-1">
             <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
               Title
@@ -94,6 +110,20 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
               />
             </div>
           </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+              Picture URL
+            </label>
+            <input
+              value={form.imageUrl}
+              onChange={(event) => setForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+              placeholder="https://..."
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            />
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              Use icons or photos that show the chore in action.
+            </p>
+          </div>
           <div className="flex flex-wrap gap-3 pt-2">
             <button
               type="submit"
@@ -112,18 +142,29 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
         </form>
       ) : (
         <div className="space-y-4">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <h3 className="font-semibold text-lg text-slate-800 dark:text-white">
-                {chore.title}
-              </h3>
-              <p className="text-sm text-slate-500 dark:text-slate-400">
-                {chore.description || 'No description yet.'}
-              </p>
+          <div className="flex items-start gap-4">
+            <div className="h-20 w-20 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+              {chore.imageUrl ? (
+                <img src={chore.imageUrl} alt={chore.title} className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-3xl">🧽</div>
+              )}
             </div>
-            <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-semibold text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
-              {chore.points} pts
-            </span>
+            <div className="flex-1 space-y-2">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="font-semibold text-lg text-slate-800 dark:text-white">
+                    {chore.title}
+                  </h3>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    {chore.description || 'No description yet.'}
+                  </p>
+                </div>
+                <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-semibold text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
+                  {chore.points} pts
+                </span>
+              </div>
+            </div>
           </div>
           <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
             {assignedMember ? `Assigned to ${assignedMember.name}` : 'Unassigned'}
@@ -160,12 +201,13 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
 
 export default function ChoresScreen() {
   const { state, addChore, toggleChoreComplete, removeChore, updateChore } = useFamboard()
-  const { familyMembers, chores } = state
+  const { familyMembers, chores, rewards } = state
   const [form, setForm] = useState({
     title: '',
     description: '',
     assignedTo: '',
     points: 10,
+    imageUrl: '',
   })
 
   const upcomingChores = useMemo(
@@ -177,6 +219,11 @@ export default function ChoresScreen() {
     [chores],
   )
 
+  const totalPointsInRewards = useMemo(
+    () => rewards.reduce((sum, reward) => sum + reward.cost, 0),
+    [rewards],
+  )
+
   const handleCreate = (event) => {
     event.preventDefault()
     if (!form.title.trim()) return
@@ -185,8 +232,9 @@ export default function ChoresScreen() {
       description: form.description.trim(),
       assignedTo: form.assignedTo || null,
       points: Number(form.points) || 0,
+      imageUrl: form.imageUrl.trim(),
     })
-    setForm({ title: '', description: '', assignedTo: '', points: 10 })
+    setForm({ title: '', description: '', assignedTo: '', points: 10, imageUrl: '' })
   }
 
   const handleToggle = (id, wasCompleted) => {
@@ -197,42 +245,88 @@ export default function ChoresScreen() {
   }
 
   return (
-    <div className="space-y-8 pb-16">
-      <section className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/70 dark:ring-slate-800">
-        <h2 className="font-display text-2xl text-slate-800 dark:text-white">
-          Add a new chore
-        </h2>
-        <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
-          Create bite-sized tasks and award generous points to keep spirits high.
-        </p>
-        <form onSubmit={handleCreate} className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-1 md:col-span-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
-              Chore title
-            </label>
+    <div className="space-y-10 pb-16">
+      <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-famboard-primary via-sky-500 to-violet-500 p-8 text-white shadow-xl">
+        <div className="absolute -left-28 top-12 h-56 w-56 rounded-full bg-white/10 blur-3xl" aria-hidden />
+        <div className="absolute -right-16 -bottom-12 h-60 w-60 rounded-full bg-violet-400/30 blur-3xl" aria-hidden />
+        <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-2xl space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">Mission control</p>
+            <h1 className="font-display text-4xl leading-tight sm:text-5xl">Organize the work, unleash the celebrations</h1>
+            <p className="text-base text-white/80">
+              Create chores, assign helpers, and mark them complete to shower the family with confetti and points.
+            </p>
+            <Link
+              to="/rewards"
+              className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+            >
+              Plan reward payouts
+            </Link>
+          </div>
+          <div className="grid w-full max-w-lg gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Chores in queue</p>
+              <p className="mt-2 text-3xl font-bold">{upcomingChores.length}</p>
+              <p className="text-xs text-white/70">Ready for a helping hand.</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Completed</p>
+              <p className="mt-2 text-3xl font-bold">{completedChores.length}</p>
+              <p className="text-xs text-white/70">Confetti-worthy moments logged.</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Reward wishlist value</p>
+              <p className="mt-2 text-3xl font-bold">{totalPointsInRewards} pts</p>
+              <p className="text-xs text-white/70">Goal points to unlock every prize.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-3xl bg-white/85 p-8 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
+        <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Create a chore</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Define what done looks like and who’s on duty.</p>
+          </div>
+          <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+            Builder tools
+          </span>
+        </header>
+        <form onSubmit={handleCreate} className="mt-6 grid gap-5 md:grid-cols-2">
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Chore title</label>
             <input
               required
               value={form.title}
               onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-lg shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
               placeholder="Tidy the playroom"
             />
           </div>
-          <div className="space-y-1 md:col-span-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
-              Description
-            </label>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Description</label>
             <textarea
               value={form.description}
               onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
-              className="min-h-[120px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              className="min-h-[140px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
               placeholder="List the steps so everyone knows what finished looks like."
             />
           </div>
-          <div className="space-y-1">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
-              Assign to
-            </label>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Picture URL</label>
+            <input
+              value={form.imageUrl}
+              onChange={(event) => setForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="https://..."
+            />
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              Add a visual clue so kids remember what to do.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Assign to</label>
             <select
               value={form.assignedTo}
               onChange={(event) => setForm((prev) => ({ ...prev, assignedTo: event.target.value }))}
@@ -246,10 +340,8 @@ export default function ChoresScreen() {
               ))}
             </select>
           </div>
-          <div className="space-y-1">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
-              Points
-            </label>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Points</label>
             <input
               type="number"
               min="0"
@@ -261,7 +353,7 @@ export default function ChoresScreen() {
           <div className="md:col-span-2">
             <button
               type="submit"
-              className="w-full rounded-full bg-famboard-primary px-6 py-3 text-lg font-semibold text-white shadow-lg transition hover:bg-famboard-dark focus:outline-none focus:ring-4 focus:ring-famboard-accent/60"
+              className="w-full rounded-full bg-emerald-500 px-6 py-3 text-lg font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-emerald-600 focus:outline-none focus:ring-4 focus:ring-emerald-300/70"
             >
               Add chore
             </button>
@@ -271,16 +363,17 @@ export default function ChoresScreen() {
 
       <section className="space-y-6">
         <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <h2 className="font-display text-2xl text-slate-800 dark:text-white">
-            Chore board
-          </h2>
-          <p className="text-sm text-slate-500 dark:text-slate-400">
-            Tap a chore to celebrate a job well done or adjust the details anytime.
-          </p>
+          <div>
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Chore board</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Tap a card to celebrate a job well done or edit the details.</p>
+          </div>
+          <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+            {chores.length} total
+          </span>
         </header>
-        <div className="grid gap-4 xl:grid-cols-2">
+        <div className="grid gap-5 xl:grid-cols-2">
           {chores.length === 0 && (
-            <p className="text-sm text-slate-500 dark:text-slate-400">
+            <p className="rounded-3xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
               No chores yet. Add one above to kick things off.
             </p>
           )}

--- a/src/pages/HomeScreen.jsx
+++ b/src/pages/HomeScreen.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { useFamboard } from '../context/FamboardContext.jsx'
 import { launchConfetti } from '../utils/confetti.js'
 
@@ -27,6 +28,14 @@ export default function HomeScreen() {
     [rewards],
   )
 
+  const totalPoints = useMemo(
+    () => familyMembers.reduce((sum, member) => sum + member.points, 0),
+    [familyMembers],
+  )
+
+  const totalChores = chores.length
+  const completedCount = completedChores.length
+
   const handleToggleChore = (chore) => {
     toggleChoreComplete(chore.id)
     if (!chore.completed) {
@@ -35,73 +44,138 @@ export default function HomeScreen() {
   }
 
   return (
-    <div className="space-y-8 pb-10">
-      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {familyMembers.map((member) => (
-          <div
-            key={member.id}
-            className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur transition hover:-translate-y-1 hover:shadow-lg dark:bg-slate-900/70 dark:ring-slate-700"
-          >
-            <div className="flex items-start justify-between">
-              <div>
-                <p className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Points
-                </p>
-                <p className="font-display text-4xl text-famboard-primary dark:text-sky-300">
-                  {member.points}
-                </p>
-              </div>
-              <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-medium text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
-                {member.name}
-              </span>
-            </div>
-            <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
-              Keep it up! Redeem rewards when you have enough points.
+    <div className="space-y-10 pb-16">
+      <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-famboard-primary via-sky-500 to-emerald-500 p-8 text-white shadow-xl">
+        <div className="absolute -left-32 top-10 h-60 w-60 rounded-full bg-white/10 blur-3xl" aria-hidden />
+        <div className="absolute -right-10 -bottom-10 h-64 w-64 rounded-full bg-emerald-400/30 blur-3xl" aria-hidden />
+        <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-2xl space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">Famboard HQ</p>
+            <h1 className="font-display text-4xl leading-tight sm:text-5xl">Celebrate progress and spark more high-fives</h1>
+            <p className="text-base text-white/80">
+              Glance at the latest wins, keep chores flowing, and hype the next big reward moment for your crew.
             </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/chores"
+                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+              >
+                View chore board
+              </Link>
+              <Link
+                to="/rewards"
+                className="inline-flex items-center justify-center rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/10"
+              >
+                Browse rewards
+              </Link>
+            </div>
           </div>
-        ))}
+          <div className="grid w-full max-w-md gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Family members</p>
+              <p className="mt-2 text-3xl font-bold">{familyMembers.length}</p>
+              <p className="text-xs text-white/70">Cheering each other on.</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points in play</p>
+              <p className="mt-2 text-3xl font-bold">{totalPoints}</p>
+              <p className="text-xs text-white/70">Ready for epic rewards.</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Chores completed</p>
+              <p className="mt-2 text-3xl font-bold">{completedCount}</p>
+              <p className="text-xs text-white/70">Out of {totalChores} total chores.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Family spotlight</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">See everyone’s momentum and encourage the next victory lap.</p>
+          </div>
+          <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+            {familyMembers.length} member{familyMembers.length === 1 ? '' : 's'}
+          </span>
+        </header>
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {familyMembers.map((member) => (
+            <div
+              key={member.id}
+              className="group relative overflow-hidden rounded-3xl border border-transparent bg-white/90 p-6 shadow-card transition hover:-translate-y-1 hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80"
+            >
+              <div className="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full bg-famboard-primary/10 blur-2xl transition group-hover:bg-famboard-primary/20" aria-hidden />
+              <div className="flex items-center gap-4">
+                <div className="h-20 w-20 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+                  {member.imageUrl ? (
+                    <img src={member.imageUrl} alt={member.name} className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-3xl">😊</div>
+                  )}
+                </div>
+                <div className="flex-1 space-y-2">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Point stash</p>
+                      <p className="font-display text-4xl text-famboard-primary dark:text-sky-300">{member.points}</p>
+                    </div>
+                    <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-medium text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
+                      {member.name}
+                    </span>
+                  </div>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">Keep it up! Rewards are just a few chores away.</p>
+                </div>
+              </div>
+            </div>
+          ))}
+          {familyMembers.length === 0 && (
+            <p className="rounded-3xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
+              Add your crew in settings to start tracking their progress.
+            </p>
+          )}
+        </div>
       </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
-        <div className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/70 dark:ring-slate-800">
+        <div className="rounded-3xl bg-white/85 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
           <header className="mb-4 flex items-center justify-between">
-            <h2 className="font-display text-2xl text-slate-800 dark:text-white">
-              Upcoming chores
-            </h2>
+            <h2 className="font-display text-2xl text-slate-800 dark:text-white">Upcoming chores</h2>
             <span className="rounded-full bg-famboard-accent/20 px-3 py-1 text-sm font-semibold text-famboard-dark dark:bg-amber-400/20 dark:text-amber-200">
               {upcomingChores.length}
             </span>
           </header>
           <div className="space-y-3">
             {upcomingChores.length === 0 && (
-              <p className="text-sm text-slate-500 dark:text-slate-400">
+              <p className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 p-4 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-slate-400">
                 Nothing on the list! Enjoy a break together.
               </p>
             )}
             {upcomingChores.map((chore) => {
-              const assigned = familyMembers.find(
-                (member) => member.id === chore.assignedTo,
-              )
+              const assigned = familyMembers.find((member) => member.id === chore.assignedTo)
               return (
                 <div
                   key={chore.id}
-                  className="flex items-center justify-between rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-sm transition hover:border-famboard-primary/50 hover:shadow dark:border-slate-700 dark:bg-slate-900/70"
+                  className="flex items-center gap-4 rounded-2xl border border-slate-200/60 bg-white/90 p-4 shadow-sm transition hover:border-famboard-primary/50 hover:shadow dark:border-slate-700 dark:bg-slate-900/70"
                 >
-                  <div>
-                    <p className="font-semibold text-slate-800 dark:text-white">
-                      {chore.title}
-                    </p>
-                    <p className="text-sm text-slate-500 dark:text-slate-400">
-                      {chore.description}
-                    </p>
-                    <p className="mt-2 text-xs font-medium uppercase tracking-wide text-slate-400">
-                      {assigned ? `Assigned to ${assigned.name}` : 'Unassigned'} ·{' '}
-                      {chore.points} pts
+                  <div className="h-16 w-16 shrink-0 overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+                    {chore.imageUrl ? (
+                      <img src={chore.imageUrl} alt={chore.title} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-2xl">🧺</div>
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <p className="font-semibold text-slate-800 dark:text-white">{chore.title}</p>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">{chore.description}</p>
+                    <p className="pt-1 text-xs font-medium uppercase tracking-wide text-slate-400">
+                      {assigned ? `Assigned to ${assigned.name}` : 'Unassigned'} · {chore.points} pts
                     </p>
                   </div>
                   <button
                     onClick={() => handleToggleChore(chore)}
-                    className="rounded-full bg-famboard-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-famboard-dark focus:outline-none focus:ring-2 focus:ring-famboard-accent focus:ring-offset-2"
+                    className="shrink-0 rounded-full bg-famboard-primary px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-dark focus:outline-none focus:ring-2 focus:ring-famboard-accent focus:ring-offset-2"
                   >
                     Done ✅
                   </button>
@@ -111,44 +185,43 @@ export default function HomeScreen() {
           </div>
         </div>
 
-        <div className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/70 dark:ring-slate-800">
+        <div className="rounded-3xl bg-white/85 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
           <header className="mb-4 flex items-center justify-between">
-            <h2 className="font-display text-2xl text-slate-800 dark:text-white">
-              Completed chores
-            </h2>
+            <h2 className="font-display text-2xl text-slate-800 dark:text-white">Completed chores</h2>
             <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-sm font-semibold text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-200">
               {completedChores.length}
             </span>
           </header>
           <div className="space-y-3">
             {completedChores.length === 0 && (
-              <p className="text-sm text-slate-500 dark:text-slate-400">
+              <p className="rounded-2xl border border-dashed border-emerald-300/60 bg-white/60 p-4 text-sm text-slate-500 shadow-inner dark:border-emerald-600/60 dark:bg-slate-900/60 dark:text-slate-400">
                 Finish chores to see them shine here.
               </p>
             )}
             {completedChores.map((chore) => {
-              const assigned = familyMembers.find(
-                (member) => member.id === chore.assignedTo,
-              )
+              const assigned = familyMembers.find((member) => member.id === chore.assignedTo)
               return (
                 <div
                   key={chore.id}
-                  className="flex items-center justify-between rounded-2xl border border-emerald-200/60 bg-white/80 p-4 shadow-sm dark:border-emerald-700 dark:bg-slate-900/70"
+                  className="flex items-center gap-4 rounded-2xl border border-emerald-200/60 bg-white/90 p-4 shadow-sm dark:border-emerald-700 dark:bg-slate-900/70"
                 >
-                  <div>
-                    <p className="font-semibold text-emerald-700 dark:text-emerald-200">
-                      {chore.title}
-                    </p>
-                    <p className="text-sm text-slate-500 dark:text-slate-400">
-                      {chore.description}
-                    </p>
-                    <p className="mt-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+                  <div className="h-16 w-16 shrink-0 overflow-hidden rounded-2xl border border-emerald-200 bg-emerald-50 shadow-inner dark:border-emerald-700 dark:bg-emerald-900/40">
+                    {chore.imageUrl ? (
+                      <img src={chore.imageUrl} alt={chore.title} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-2xl">🌟</div>
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <p className="font-semibold text-emerald-700 dark:text-emerald-200">{chore.title}</p>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">{chore.description}</p>
+                    <p className="pt-1 text-xs font-medium uppercase tracking-wide text-slate-400">
                       {assigned ? `By ${assigned.name}` : 'Unassigned'} · {chore.points} pts
                     </p>
                   </div>
                   <button
                     onClick={() => toggleChoreComplete(chore.id)}
-                    className="rounded-full border border-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-600 transition hover:bg-emerald-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2"
+                    className="shrink-0 rounded-full border border-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-600 transition hover:-translate-y-0.5 hover:bg-emerald-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2"
                   >
                     Undo
                   </button>
@@ -159,36 +232,40 @@ export default function HomeScreen() {
         </div>
       </section>
 
-      <section className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/70 dark:ring-slate-800">
-        <header className="mb-4 flex items-center justify-between">
-          <h2 className="font-display text-2xl text-slate-800 dark:text-white">
-            Reward store
-          </h2>
+      <section className="rounded-3xl bg-white/85 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
+        <header className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Reward store preview</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Get inspired by what’s waiting once the points pile up.</p>
+          </div>
           <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-semibold text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
-            {availableRewards.length}
+            {availableRewards.length} reward{availableRewards.length === 1 ? '' : 's'}
           </span>
         </header>
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {availableRewards.map((reward) => (
             <div
               key={reward.id}
-              className="flex flex-col justify-between rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-sm transition hover:border-famboard-primary/60 hover:shadow dark:border-slate-700 dark:bg-slate-900/80"
+              className="group relative flex flex-col justify-between overflow-hidden rounded-3xl border border-transparent bg-white/90 p-5 shadow-card transition hover:-translate-y-1 hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80"
             >
-              <div>
-                <p className="font-semibold text-slate-800 dark:text-white">
-                  {reward.title}
-                </p>
-                <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                  {reward.description}
-                </p>
+              <div className="pointer-events-none absolute -right-12 -top-12 h-32 w-32 rounded-full bg-famboard-primary/10 blur-3xl transition group-hover:bg-famboard-primary/20" aria-hidden />
+              <div className="space-y-2">
+                <div className="h-24 w-full overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+                  {reward.imageUrl ? (
+                    <img src={reward.imageUrl} alt={reward.title} className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-3xl">🎈</div>
+                  )}
+                </div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Reward idea</p>
+                <p className="text-lg font-semibold text-slate-800 dark:text-white">{reward.title}</p>
+                <p className="text-sm text-slate-500 dark:text-slate-400">{reward.description || 'Add a description in settings to build excitement.'}</p>
               </div>
-              <p className="mt-4 text-lg font-bold text-famboard-primary dark:text-sky-300">
-                {reward.cost} pts
-              </p>
+              <p className="mt-4 text-lg font-bold text-famboard-primary dark:text-sky-300">{reward.cost} pts</p>
             </div>
           ))}
           {availableRewards.length === 0 && (
-            <p className="text-sm text-slate-500 dark:text-slate-400">
+            <p className="rounded-3xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
               Add rewards in the Rewards tab to motivate the crew!
             </p>
           )}

--- a/src/pages/RewardsScreen.jsx
+++ b/src/pages/RewardsScreen.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useFamboard } from '../context/FamboardContext.jsx'
 
 function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
@@ -8,13 +9,26 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
     title: reward.title,
     description: reward.description,
     cost: reward.cost,
+    imageUrl: reward.imageUrl ?? '',
   })
+
+  const selectedMemberData = useMemo(
+    () => members.find((member) => member.id === selectedMember),
+    [members, selectedMember],
+  )
+
+  const progress = useMemo(() => {
+    if (!selectedMemberData) return 0
+    if (reward.cost === 0) return 100
+    return Math.min(100, Math.round((selectedMemberData.points / reward.cost) * 100))
+  }, [reward.cost, selectedMemberData])
 
   useEffect(() => {
     setForm({
       title: reward.title,
       description: reward.description,
       cost: reward.cost,
+      imageUrl: reward.imageUrl ?? '',
     })
   }, [reward])
 
@@ -38,14 +52,28 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
       title: form.title.trim(),
       description: form.description.trim(),
       cost: Number(form.cost) || 0,
+      imageUrl: form.imageUrl.trim(),
     })
     setIsEditing(false)
   }
 
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-sm transition hover:border-famboard-primary/60 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900/80">
+    <div className="group relative overflow-hidden rounded-3xl border border-transparent bg-white/90 p-6 shadow-card transition hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80">
+      <div className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full bg-famboard-primary/10 blur-2xl transition group-hover:bg-famboard-primary/20" aria-hidden />
       {isEditing ? (
-        <form className="space-y-3" onSubmit={handleSubmit}>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="flex items-center gap-3">
+            <div className="h-20 w-20 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+              {form.imageUrl ? (
+                <img src={form.imageUrl} alt={form.title} className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-3xl">🎉</div>
+              )}
+            </div>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Add a picture so kids can cheer for this reward instantly.
+            </p>
+          </div>
           <div className="space-y-1">
             <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
               Reward title
@@ -54,7 +82,7 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
               required
               value={form.title}
               onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
             />
           </div>
           <div className="space-y-1">
@@ -64,9 +92,23 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
             <textarea
               value={form.description}
               onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
               rows={3}
             />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+              Picture URL
+            </label>
+            <input
+              value={form.imageUrl}
+              onChange={(event) => setForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+              placeholder="https://..."
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            />
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              Use a photo or drawing that shows the reward.
+            </p>
           </div>
           <div className="space-y-1">
             <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
@@ -77,7 +119,7 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
               min="0"
               value={form.cost}
               onChange={(event) => setForm((prev) => ({ ...prev, cost: event.target.value }))}
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
             />
           </div>
           <div className="flex flex-wrap gap-3 pt-2">
@@ -98,18 +140,29 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
         </form>
       ) : (
         <div className="space-y-4">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <h3 className="text-lg font-semibold text-slate-800 dark:text-white">
-                {reward.title}
-              </h3>
-              <p className="text-sm text-slate-500 dark:text-slate-400">
-                {reward.description || 'Add a fun description to get everyone excited!'}
-              </p>
+          <div className="flex items-start gap-4">
+            <div className="h-20 w-20 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+              {reward.imageUrl ? (
+                <img src={reward.imageUrl} alt={reward.title} className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-3xl">🎁</div>
+              )}
             </div>
-            <span className="rounded-full bg-famboard-accent/20 px-3 py-1 text-sm font-semibold text-famboard-dark dark:bg-amber-400/20 dark:text-amber-200">
-              {reward.cost} pts
-            </span>
+            <div className="flex-1 space-y-2">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-xl font-semibold text-slate-900 transition group-hover:text-famboard-primary dark:text-white">
+                    {reward.title}
+                  </h3>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    {reward.description || 'Add a fun description to get everyone excited!'}
+                  </p>
+                </div>
+                <span className="rounded-full bg-gradient-to-r from-famboard-primary/10 via-famboard-accent/20 to-emerald-400/20 px-3 py-1 text-sm font-semibold text-famboard-dark dark:from-sky-500/10 dark:via-emerald-400/20 dark:to-amber-300/20 dark:text-amber-200">
+                  {reward.cost} pts
+                </span>
+              </div>
+            </div>
           </div>
           <div className="space-y-3">
             <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -128,6 +181,22 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
               ))}
             </select>
           </div>
+          {selectedMemberData && (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <span>Progress</span>
+                <span>
+                  {Math.min(selectedMemberData.points, reward.cost)} / {reward.cost || 0} pts
+                </span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200/80 dark:bg-slate-700/80">
+                <div
+                  className={`h-full rounded-full bg-gradient-to-r from-famboard-primary via-sky-500 to-emerald-400 transition-all duration-500`}
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </div>
+          )}
           <div className="flex flex-wrap items-center gap-3">
             <button
               onClick={() => selectedMember && onRedeem(selectedMember, reward.id)}
@@ -166,94 +235,110 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
 }
 
 export default function RewardsScreen() {
-  const { state, addReward, redeemReward, removeReward, updateReward } = useFamboard()
+  const { state, redeemReward, removeReward, updateReward } = useFamboard()
   const { familyMembers, rewards } = state
-  const [form, setForm] = useState({
-    title: '',
-    description: '',
-    cost: 20,
-  })
 
-  const handleCreate = (event) => {
-    event.preventDefault()
-    if (!form.title.trim()) return
-    addReward({
-      title: form.title.trim(),
-      description: form.description.trim(),
-      cost: Number(form.cost) || 0,
-    })
-    setForm({ title: '', description: '', cost: 20 })
-  }
+  const totalPoints = useMemo(
+    () => familyMembers.reduce((sum, member) => sum + member.points, 0),
+    [familyMembers],
+  )
+
+  const readyToRedeem = useMemo(
+    () =>
+      rewards.filter((reward) =>
+        familyMembers.some((member) => reward.cost === 0 || member.points >= reward.cost),
+      ).length,
+    [familyMembers, rewards],
+  )
+
+  const averageCost = useMemo(() => {
+    if (rewards.length === 0) return 0
+    const totalCost = rewards.reduce((sum, reward) => sum + reward.cost, 0)
+    return Math.round(totalCost / rewards.length)
+  }, [rewards])
+
+  const topMember = useMemo(() => {
+    if (familyMembers.length === 0) return null
+    return familyMembers.reduce((prev, current) =>
+      current.points > prev.points ? current : prev,
+    )
+  }, [familyMembers])
 
   return (
-    <div className="space-y-8 pb-16">
-      <section className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/70 dark:ring-slate-800">
-        <h2 className="font-display text-2xl text-slate-800 dark:text-white">
-          Dream up a new reward
-        </h2>
-        <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
-          Celebrate wins with experiences and treats worth working toward.
-        </p>
-        <form onSubmit={handleCreate} className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-1 md:col-span-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
-              Reward title
-            </label>
-            <input
-              required
-              value={form.title}
-              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-lg shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-              placeholder="Family game night"
-            />
+    <div className="space-y-10 pb-16">
+      <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-famboard-primary via-sky-500 to-emerald-500 p-8 text-white shadow-xl">
+        <div className="absolute -left-24 top-10 h-56 w-56 rounded-full bg-white/10 blur-3xl" aria-hidden />
+        <div className="absolute -right-10 -bottom-10 h-60 w-60 rounded-full bg-emerald-400/20 blur-3xl" aria-hidden />
+        <div className="relative space-y-8">
+          <div className="max-w-3xl space-y-3">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Celebration station</p>
+            <h2 className="font-display text-4xl leading-tight sm:text-5xl">Turn points into unforgettable family moments</h2>
+            <p className="text-base text-white/80">
+              Browse the current reward shelf, see who is closest to cashing in, and cheer everyone on.
+            </p>
           </div>
-          <div className="space-y-1 md:col-span-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
-              Description
-            </label>
-            <textarea
-              value={form.description}
-              onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
-              className="min-h-[120px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-              placeholder="Include all the fun details that make this reward special."
-            />
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Rewards ready to redeem</p>
+              <p className="mt-2 text-3xl font-bold">{readyToRedeem}</p>
+              <p className="text-xs text-white/70">Family treats are within reach right now.</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points in circulation</p>
+              <p className="mt-2 text-3xl font-bold">{totalPoints}</p>
+              <p className="text-xs text-white/70">Earned by your hard-working crew.</p>
+            </div>
+            <div className="rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Average reward cost</p>
+              <p className="mt-2 text-3xl font-bold">{averageCost} pts</p>
+              <p className="text-xs text-white/70">Plan chores that match the excitement.</p>
+            </div>
           </div>
-          <div className="space-y-1">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
-              Cost (points)
-            </label>
-            <input
-              type="number"
-              min="0"
-              value={form.cost}
-              onChange={(event) => setForm((prev) => ({ ...prev, cost: event.target.value }))}
-              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-            />
-          </div>
-          <div className="md:col-span-2">
-            <button
-              type="submit"
-              className="w-full rounded-full bg-emerald-500 px-6 py-3 text-lg font-semibold text-white shadow-lg transition hover:bg-emerald-600 focus:outline-none focus:ring-4 focus:ring-emerald-300/70"
+          {topMember && (
+            <div className="flex flex-col gap-4 rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points leader</p>
+                <p className="text-lg font-semibold">{topMember.name}</p>
+                <p className="text-sm text-white/70">{topMember.points} points earned and ready to celebrate.</p>
+              </div>
+              <Link
+                to="/settings"
+                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+              >
+                Create new rewards in settings
+              </Link>
+            </div>
+          )}
+          {!topMember && (
+            <Link
+              to="/settings"
+              className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
             >
-              Add reward
-            </button>
-          </div>
-        </form>
+              Head to settings to create your first reward
+            </Link>
+          )}
+        </div>
       </section>
 
       <section className="space-y-6">
-        <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <h2 className="font-display text-2xl text-slate-800 dark:text-white">
-            Reward shelf
-          </h2>
-          <p className="text-sm text-slate-500 dark:text-slate-400">
-            Pick who redeems the reward and the points will update instantly.
-          </p>
-        </header>
-        <div className="grid gap-4 xl:grid-cols-2">
-          {rewards.length === 0 && (
+        <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h3 className="font-display text-3xl text-slate-800 dark:text-white">Reward shelf</h3>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Add your first reward above to get everyone motivated.
+              Pick who redeems the reward and watch their points sparkle away in real time.
+            </p>
+          </div>
+          <Link
+            to="/settings"
+            className="inline-flex items-center justify-center rounded-full border border-famboard-primary/60 px-4 py-2 text-sm font-semibold text-famboard-primary transition hover:bg-famboard-primary hover:text-white"
+          >
+            Manage rewards in settings
+          </Link>
+        </header>
+        <div className="grid gap-5 lg:grid-cols-2">
+          {rewards.length === 0 && (
+            <p className="rounded-3xl border border-dashed border-slate-300/80 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/80 dark:bg-slate-900/70 dark:text-slate-400">
+              The shelf is empty—visit the settings admin page to dream up your first reward.
             </p>
           )}
           {rewards.map((reward) => (

--- a/src/pages/SettingsScreen.jsx
+++ b/src/pages/SettingsScreen.jsx
@@ -1,21 +1,39 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useFamboard } from '../context/FamboardContext.jsx'
 
 function MemberCard({ member, onSave, onRemove }) {
   const [name, setName] = useState(member.name)
+  const [imageUrl, setImageUrl] = useState(member.imageUrl ?? '')
 
   useEffect(() => {
     setName(member.name)
+    setImageUrl(member.imageUrl ?? '')
   }, [member])
 
   const handleSubmit = (event) => {
     event.preventDefault()
-    onSave(member.id, { name: name.trim() || member.name })
+    onSave(member.id, {
+      name: name.trim() || member.name,
+      imageUrl: imageUrl.trim(),
+    })
   }
 
   return (
     <div className="rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-sm transition hover:border-famboard-primary/60 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900/80">
-      <form onSubmit={handleSubmit} className="space-y-3">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-16 w-16 overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-600 dark:bg-slate-800">
+            {imageUrl ? (
+              <img src={imageUrl} alt={member.name} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-2xl">👤</div>
+            )}
+          </div>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Add a friendly face so kids can spot their card at a glance.
+          </p>
+        </div>
         <div className="space-y-1">
           <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
             Family member name
@@ -25,6 +43,20 @@ function MemberCard({ member, onSave, onRemove }) {
             onChange={(event) => setName(event.target.value)}
             className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
           />
+        </div>
+        <div className="space-y-1">
+          <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+            Picture URL
+          </label>
+          <input
+            value={imageUrl}
+            onChange={(event) => setImageUrl(event.target.value)}
+            placeholder="https://..."
+            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+          />
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            Paste a link to a photo or illustration your kid loves.
+          </p>
         </div>
         <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
           Points: <span className="font-semibold text-famboard-primary dark:text-sky-300">{member.points}</span>
@@ -49,23 +81,154 @@ function MemberCard({ member, onSave, onRemove }) {
   )
 }
 
+function RewardAdminCard({ reward, onSave, onRemove }) {
+  const [form, setForm] = useState({
+    title: reward.title,
+    description: reward.description,
+    cost: reward.cost,
+    imageUrl: reward.imageUrl ?? '',
+  })
+
+  useEffect(() => {
+    setForm({
+      title: reward.title,
+      description: reward.description,
+      cost: reward.cost,
+      imageUrl: reward.imageUrl ?? '',
+    })
+  }, [reward])
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    onSave(reward.id, {
+      title: form.title.trim() || reward.title,
+      description: form.description.trim(),
+      cost: Number(form.cost) || 0,
+      imageUrl: form.imageUrl.trim(),
+    })
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-sm transition hover:border-famboard-primary/60 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900/80">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-16 w-16 overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-600 dark:bg-slate-800">
+            {form.imageUrl ? (
+              <img src={form.imageUrl} alt={form.title} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-2xl">🎁</div>
+            )}
+          </div>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Visual rewards help non-readers understand the prize instantly.
+          </p>
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Reward title
+          </label>
+          <input
+            value={form.title}
+            onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+          />
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Description
+          </label>
+          <textarea
+            value={form.description}
+            onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            rows={3}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Picture URL
+          </label>
+          <input
+            value={form.imageUrl}
+            onChange={(event) => setForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+            placeholder="https://..."
+            className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+          />
+          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+            Use bright photos or icons to make the reward pop.
+          </p>
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Cost (points)
+          </label>
+          <input
+            type="number"
+            min="0"
+            value={form.cost}
+            onChange={(event) => setForm((prev) => ({ ...prev, cost: event.target.value }))}
+            className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+          />
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="submit"
+            className="flex-1 rounded-full bg-famboard-primary px-4 py-2 text-sm font-semibold text-white shadow focus:outline-none focus:ring-2 focus:ring-famboard-accent focus:ring-offset-2"
+          >
+            Save reward
+          </button>
+          <button
+            type="button"
+            onClick={() => onRemove(reward.id)}
+            className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
+          >
+            Remove
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
 export default function SettingsScreen() {
   const {
     state,
     addFamilyMember,
     updateFamilyMember,
     removeFamilyMember,
+    addReward,
+    updateReward,
+    removeReward,
     setTheme,
     resetAll,
   } = useFamboard()
-  const { familyMembers, theme } = state
+  const { familyMembers, rewards, theme } = state
   const [memberName, setMemberName] = useState('')
+  const [memberImage, setMemberImage] = useState('')
+  const [rewardForm, setRewardForm] = useState({
+    title: '',
+    description: '',
+    cost: 20,
+    imageUrl: '',
+  })
+
+  const totalPoints = useMemo(
+    () => familyMembers.reduce((sum, member) => sum + member.points, 0),
+    [familyMembers],
+  )
+
+  const averageRewardCost = useMemo(() => {
+    if (rewards.length === 0) return 0
+    const totalCost = rewards.reduce((sum, reward) => sum + reward.cost, 0)
+    return Math.round(totalCost / rewards.length)
+  }, [rewards])
 
   const handleAddMember = (event) => {
     event.preventDefault()
     if (!memberName.trim()) return
-    addFamilyMember(memberName.trim())
+    addFamilyMember({ name: memberName.trim(), imageUrl: memberImage.trim() })
     setMemberName('')
+    setMemberImage('')
   }
 
   const handleRemove = (id) => {
@@ -92,24 +255,78 @@ export default function SettingsScreen() {
     setTheme(theme === 'dark' ? 'light' : 'dark')
   }
 
+  const handleCreateReward = (event) => {
+    event.preventDefault()
+    if (!rewardForm.title.trim()) return
+    addReward({
+      title: rewardForm.title.trim(),
+      description: rewardForm.description.trim(),
+      cost: Number(rewardForm.cost) || 0,
+      imageUrl: rewardForm.imageUrl.trim(),
+    })
+    setRewardForm({ title: '', description: '', cost: 20, imageUrl: '' })
+  }
+
   return (
-    <div className="space-y-8 pb-16">
-      <section className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/70 dark:ring-slate-800">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <div className="space-y-10 pb-16">
+      <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-famboard-primary via-sky-500 to-rose-500 p-8 text-white shadow-xl">
+        <div className="absolute -left-24 top-12 h-60 w-60 rounded-full bg-white/10 blur-3xl" aria-hidden />
+        <div className="absolute -right-16 -bottom-12 h-64 w-64 rounded-full bg-rose-400/30 blur-3xl" aria-hidden />
+        <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-2xl space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">Control center</p>
+            <h1 className="font-display text-4xl leading-tight sm:text-5xl">Tune your Famboard to match your family vibe</h1>
+            <p className="text-base text-white/80">
+              Update members, craft rewards, and reset the board when it’s time for a fresh season of teamwork.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <button
+                onClick={toggleTheme}
+                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+              >
+                {theme === 'dark' ? 'Switch to light mode ☀️' : 'Switch to dark mode 🌙'}
+              </button>
+              <Link
+                to="/rewards"
+                className="inline-flex items-center justify-center rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/10"
+              >
+                Preview rewards
+              </Link>
+            </div>
+          </div>
+          <div className="grid w-full max-w-lg gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Family members</p>
+              <p className="mt-2 text-3xl font-bold">{familyMembers.length}</p>
+              <p className="text-xs text-white/70">Currently on the roster.</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Rewards crafted</p>
+              <p className="mt-2 text-3xl font-bold">{rewards.length}</p>
+              <p className="text-xs text-white/70">Ready to motivate everyone.</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points in circulation</p>
+              <p className="mt-2 text-3xl font-bold">{totalPoints}</p>
+              <p className="text-xs text-white/70">Average reward cost {averageRewardCost} pts.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-3xl bg-white/85 p-8 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
+        <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <div>
-            <h2 className="font-display text-2xl text-slate-800 dark:text-white">Family roster</h2>
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Family roster</h2>
             <p className="text-sm text-slate-500 dark:text-slate-400">
               Add everyone who helps out and keep names up to date as kids grow.
             </p>
           </div>
-          <button
-            onClick={toggleTheme}
-            className="self-start rounded-full bg-slate-900/10 px-4 py-2 text-sm font-semibold text-slate-700 shadow-inner transition hover:bg-slate-900/20 focus:outline-none focus:ring-2 focus:ring-famboard-primary focus:ring-offset-2 dark:bg-slate-100/10 dark:text-slate-100 dark:hover:bg-slate-100/20"
-          >
-            {theme === 'dark' ? 'Switch to light mode ☀️' : 'Switch to dark mode 🌙'}
-          </button>
-        </div>
-        <form onSubmit={handleAddMember} className="mt-6 grid gap-4 md:grid-cols-[2fr_1fr]">
+          <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+            Team management
+          </span>
+        </header>
+        <form onSubmit={handleAddMember} className="mt-6 grid gap-4 md:grid-cols-[2fr_2fr_1fr]">
           <div className="space-y-1">
             <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
               New family member
@@ -120,6 +337,20 @@ export default function SettingsScreen() {
               className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
               placeholder="Add a name"
             />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+              Picture URL
+            </label>
+            <input
+              value={memberImage}
+              onChange={(event) => setMemberImage(event.target.value)}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="https://..."
+            />
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              Optional: add a photo or favorite character for quick recognition.
+            </p>
           </div>
           <button
             type="submit"
@@ -140,14 +371,88 @@ export default function SettingsScreen() {
         </div>
       </section>
 
-      <section className="rounded-3xl bg-white/80 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/70 dark:ring-slate-800">
-        <h2 className="font-display text-2xl text-slate-800 dark:text-white">Reset Famboard</h2>
+      <section className="rounded-3xl bg-white/85 p-8 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-2xl space-y-2">
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Reward workshop</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Curate the experiences your family works toward. Update descriptions, adjust point costs, and remove retired ideas.
+            </p>
+          </div>
+          <p className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+            Admin tools
+          </p>
+        </div>
+        <form onSubmit={handleCreateReward} className="mt-6 grid gap-5 md:grid-cols-2">
+          <div className="space-y-1 md:col-span-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Reward title</label>
+            <input
+              value={rewardForm.title}
+              onChange={(event) => setRewardForm((prev) => ({ ...prev, title: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="Family movie marathon"
+            />
+          </div>
+          <div className="space-y-1 md:col-span-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Description</label>
+            <textarea
+              value={rewardForm.description}
+              onChange={(event) => setRewardForm((prev) => ({ ...prev, description: event.target.value }))}
+              className="min-h-[120px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="Add the cozy details or rules that make this reward special."
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Picture URL</label>
+            <input
+              value={rewardForm.imageUrl}
+              onChange={(event) => setRewardForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="https://..."
+            />
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              Show what the reward looks like so little ones know what they are earning.
+            </p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Cost (points)</label>
+            <input
+              type="number"
+              min="0"
+              value={rewardForm.cost}
+              onChange={(event) => setRewardForm((prev) => ({ ...prev, cost: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="w-full rounded-full bg-emerald-500 px-6 py-3 text-lg font-semibold text-white shadow-lg transition hover:bg-emerald-600 focus:outline-none focus:ring-4 focus:ring-emerald-300/70"
+            >
+              Add reward
+            </button>
+          </div>
+        </form>
+        <div className="mt-8 grid gap-5 xl:grid-cols-2">
+          {rewards.map((reward) => (
+            <RewardAdminCard key={reward.id} reward={reward} onSave={updateReward} onRemove={removeReward} />
+          ))}
+          {rewards.length === 0 && (
+            <p className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
+              No rewards yet—add your first idea above to populate the reward shelf.
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-3xl bg-white/85 p-8 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
+        <h2 className="font-display text-3xl text-slate-800 dark:text-white">Reset Famboard</h2>
         <p className="text-sm text-slate-500 dark:text-slate-400">
           Start fresh at the beginning of a new month or chore season. This wipes points, chores, and rewards.
         </p>
         <button
           onClick={handleReset}
-          className="mt-4 w-full rounded-full border border-rose-400 px-6 py-3 text-lg font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-4 focus:ring-rose-200 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
+          className="mt-6 w-full rounded-full border border-rose-400 px-6 py-3 text-lg font-semibold text-rose-500 transition hover:-translate-y-0.5 hover:bg-rose-50 focus:outline-none focus:ring-4 focus:ring-rose-200 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
         >
           Reset all data
         </button>


### PR DESCRIPTION
## Summary
- add optional image URLs to famboard data, creation flows, and editing tools
- display chore, reward, and member imagery across the home, chores, rewards, and settings screens with playful fallbacks for non-readers
- refresh default seed data with kid-friendly example photos to showcase the visual-first experience

## Testing
- npm run build *(fails: vite command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e0d82be48326a35c18b11581ddc7