### PR TITLE
Add update refresh prompt and surface app version

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -8,12 +8,13 @@ const OFFLINE_URLS = [
   `${APP_BASE}icons/icon-192.svg`,
   `${APP_BASE}icons/icon-512.svg`,
 ]
+const OFFLINE_REQUESTS = OFFLINE_URLS.map((url) => new Request(url, { cache: 'reload' }))
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches
       .open(CACHE_NAME)
-      .then((cache) => cache.addAll(OFFLINE_URLS))
+      .then((cache) => cache.addAll(OFFLINE_REQUESTS))
       .then(() => self.skipWaiting()),
   )
 })
@@ -31,6 +32,12 @@ self.addEventListener('activate', (event) => {
       )
       .then(() => self.clients.claim()),
   )
+})
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
 })
 
 self.addEventListener('fetch', (event) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { NavLink, Navigate, Outlet, Route, Routes } from 'react-router-dom'
 import HomeScreen from './pages/HomeScreen.jsx'
 import ChoresScreen from './pages/ChoresScreen.jsx'
@@ -28,6 +29,29 @@ function ThemeToggle() {
 
 function Layout() {
   const { isHydrated } = useFamboard()
+  const [updateStatus, setUpdateStatus] = useState('hidden')
+
+  useEffect(() => {
+    if (window.__famboardUpdateReady) {
+      setUpdateStatus('available')
+    }
+
+    const handleUpdateAvailable = () => {
+      setUpdateStatus('available')
+    }
+
+    window.addEventListener('famboard:sw-update-available', handleUpdateAvailable)
+
+    return () => {
+      window.removeEventListener('famboard:sw-update-available', handleUpdateAvailable)
+    }
+  }, [])
+
+  const applyUpdate = () => {
+    if (updateStatus === 'updating') return
+    setUpdateStatus('updating')
+    window.dispatchEvent(new Event('famboard:sw-apply-update'))
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-100 via-slate-50 to-famboard-surface text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
@@ -67,6 +91,26 @@ function Layout() {
           </div>
         </nav>
       </header>
+      {updateStatus !== 'hidden' && (
+        <div className="border-b border-amber-200 bg-amber-50/90 text-amber-900 backdrop-blur dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold uppercase tracking-wide">Update available</p>
+              <p className="text-sm text-amber-800 dark:text-amber-100/80">
+                A fresh version of Famboard is ready. Refresh to grab the latest chores magic.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={applyUpdate}
+              disabled={updateStatus === 'updating'}
+              className="inline-flex items-center justify-center rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-amber-50 shadow transition hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 disabled:cursor-wait disabled:opacity-75 dark:bg-amber-400 dark:text-slate-900 dark:hover:bg-amber-300"
+            >
+              {updateStatus === 'updating' ? 'Refreshing…' : 'Refresh now'}
+            </button>
+          </div>
+        </div>
+      )}
       <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8">
         {isHydrated ? (
           <Outlet />

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -34,10 +34,75 @@ if (import.meta.env.PROD) {
 }
 
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  const swUrl = `${import.meta.env.BASE_URL}sw.js`
+  if (typeof window.__famboardUpdateReady === 'undefined') {
+    window.__famboardUpdateReady = false
+  }
+  let shouldReloadAfterUpdate = false
+  let isReloading = false
+  let pendingUpdateWorker = null
+
+  const notifyUpdateAvailable = (worker) => {
+    if (!worker || !navigator.serviceWorker.controller) {
+      return
+    }
+
+    pendingUpdateWorker = worker
+    window.__famboardUpdateReady = true
+    window.dispatchEvent(new Event('famboard:sw-update-available'))
+  }
+
+  window.addEventListener('famboard:sw-apply-update', () => {
+    if (!pendingUpdateWorker) {
+      return
+    }
+
+    shouldReloadAfterUpdate = true
+    window.__famboardUpdateReady = false
+    pendingUpdateWorker.postMessage({ type: 'SKIP_WAITING' })
+    pendingUpdateWorker = null
+  })
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!shouldReloadAfterUpdate || isReloading) return
+    if (!navigator.serviceWorker.controller) return
+    isReloading = true
+    window.location.reload()
+  })
+
   window.addEventListener('load', () => {
-    const swUrl = `${import.meta.env.BASE_URL}sw.js`
     navigator.serviceWorker
       .register(swUrl)
+      .then((registration) => {
+        if (registration.waiting) {
+          notifyUpdateAvailable(registration.waiting)
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const worker = registration.installing
+          if (!worker) return
+
+          worker.addEventListener('statechange', () => {
+            if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+              notifyUpdateAvailable(worker)
+            }
+          })
+        })
+
+        const updateRegistration = () => {
+          registration.update().catch((error) => {
+            console.warn('Service worker update failed', error)
+          })
+        }
+
+        document.addEventListener('visibilitychange', () => {
+          if (document.visibilityState === 'visible') {
+            updateRegistration()
+          }
+        })
+
+        setInterval(updateRegistration, 60 * 60 * 1000)
+      })
       .catch((error) => console.error('Service worker registration failed', error))
   })
 }

--- a/src/pages/SettingsScreen.jsx
+++ b/src/pages/SettingsScreen.jsx
@@ -1,6 +1,10 @@
+/* global __APP_VERSION__ */
+
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useFamboard } from '../context/FamboardContext.jsx'
+
+const APP_VERSION = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev'
 
 function MemberCard({ member, onSave, onRemove }) {
   const [name, setName] = useState(member.name)
@@ -456,6 +460,9 @@ export default function SettingsScreen() {
         >
           Reset all data
         </button>
+        <p className="mt-6 text-xs font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+          App version <span className="font-semibold text-slate-600 dark:text-slate-300">{APP_VERSION}</span>
+        </p>
       </section>
     </div>
   )

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   base: '/famboard/',
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version ?? 'dev'),
+  },
 })


### PR DESCRIPTION
## Summary
- surface a banner when the service worker has an update ready and let the user trigger the refresh
- coordinate update flow between the service worker registration and UI so reload waits for user confirmation
- expose the packaged app version in the settings screen using Vite build-time metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ea039c808326b5803419175aab21