### PR TITLE
Automate package version bump during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -21,12 +21,32 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20.19.0
           cache: npm
+
+      - name: Bump package version
+        if: github.actor != 'github-actions[bot]'
+        run: npm run bump:version
+
+      - name: Commit version bump
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+          else
+            VERSION=$(node -p "require('./package.json').version")
+            git commit -m "chore: bump version to ${VERSION}"
+            git push
+          fi
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "bump:version": "node scripts/bump-version.js"
   },
   "dependencies": {
     "canvas-confetti": "^1.9.3",

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+const packageJsonPath = path.resolve('package.json');
+const packageLockPath = path.resolve('package-lock.json');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function incrementPatch(version) {
+  const parts = version.split('.').map((part) => Number.parseInt(part, 10));
+  if (parts.length !== 3 || parts.some((part) => Number.isNaN(part) || part < 0)) {
+    throw new Error(`Unsupported version format: ${version}`);
+  }
+
+  parts[2] += 1;
+  return parts.join('.');
+}
+
+const packageJson = readJson(packageJsonPath);
+const currentVersion = packageJson.version ?? '0.0.0';
+const nextVersion = incrementPatch(currentVersion);
+
+packageJson.version = nextVersion;
+writeJson(packageJsonPath, packageJson);
+
+if (fs.existsSync(packageLockPath)) {
+  const packageLockJson = readJson(packageLockPath);
+  if (packageLockJson.version) {
+    packageLockJson.version = nextVersion;
+  }
+  if (
+    packageLockJson.packages &&
+    packageLockJson.packages[''] &&
+    packageLockJson.packages[''].version
+  ) {
+    packageLockJson.packages[''].version = nextVersion;
+  }
+  writeJson(packageLockPath, packageLockJson);
+}
+
+console.log(`Version bumped from ${currentVersion} to ${nextVersion}`);


### PR DESCRIPTION
## Summary
- add a reusable Node script that increments the package version across package.json and package-lock.json
- update the deploy workflow to bump the version, commit, and push before building
- expose an npm script to run the version bump locally when needed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ed80177883268ea39d23d1e4f9b5