### PR TITLE
Add member switcher and centralize chore management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { NavLink, Navigate, Outlet, Route, Routes } from 'react-router-dom'
 import HomeScreen from './pages/HomeScreen.jsx'
 import ChoresScreen from './pages/ChoresScreen.jsx'
@@ -24,6 +24,96 @@ function ThemeToggle() {
     >
       {isDark ? '🌙 Dark' : '☀️ Light'}
     </button>
+  )
+}
+
+function UserSwitcher() {
+  const { state, setActiveView } = useFamboard()
+  const { familyMembers, chores, activeView } = state
+
+  const totalFamilyPoints = useMemo(
+    () => familyMembers.reduce((sum, member) => sum + member.points, 0),
+    [familyMembers],
+  )
+
+  const familyOpenChores = useMemo(
+    () => chores.filter((chore) => !chore.completed).length,
+    [chores],
+  )
+
+  const getMemberChoreCount = (memberId) =>
+    chores.filter((chore) => !chore.completed && chore.assignedTo === memberId).length
+
+  const tileBaseClasses =
+    'flex min-w-[15rem] flex-1 items-center gap-4 rounded-3xl border px-4 py-4 text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-famboard-primary/40 focus:ring-offset-2'
+
+  return (
+    <section className="mx-auto mt-4 w-full max-w-6xl px-4">
+      <div className="flex snap-x gap-3 overflow-x-auto pb-2 md:flex-wrap md:pb-0">
+        <button
+          type="button"
+          onClick={() => setActiveView('family')}
+          className={`${tileBaseClasses} snap-center ${
+            activeView === 'family'
+              ? 'border-famboard-primary bg-famboard-primary/10 text-famboard-dark dark:border-sky-500 dark:bg-sky-500/10 dark:text-sky-100'
+              : 'border-white/60 bg-white/80 text-slate-600 hover:border-famboard-primary/40 hover:bg-famboard-primary/10 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-200'
+          }`}
+        >
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-famboard-primary/20 text-3xl dark:bg-sky-500/20" aria-hidden>
+            👨‍👩‍👧‍👦
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold uppercase tracking-wide">Family view</p>
+            <p className="text-lg font-display text-slate-900 dark:text-white">Everyone</p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              {familyMembers.length} members · {familyOpenChores} chores · {totalFamilyPoints} pts
+            </p>
+          </div>
+        </button>
+        {familyMembers.map((member) => {
+          const upcoming = getMemberChoreCount(member.id)
+          const isActive = activeView === member.id
+          return (
+            <button
+              type="button"
+              key={member.id}
+              onClick={() => setActiveView(member.id)}
+              className={`${tileBaseClasses} snap-center ${
+                isActive
+                  ? 'border-famboard-primary bg-famboard-primary/10 text-famboard-dark dark:border-sky-500 dark:bg-sky-500/10 dark:text-sky-100'
+                  : 'border-white/60 bg-white/80 text-slate-600 hover:border-famboard-primary/40 hover:bg-famboard-primary/10 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-200'
+              }`}
+            >
+              <div className="h-16 w-16 shrink-0 overflow-hidden rounded-2xl border border-white/80 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+                {member.imageUrl ? (
+                  <img src={member.imageUrl} alt={member.name} className="h-full w-full object-cover" />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-2xl">😊</div>
+                )}
+              </div>
+              <div className="space-y-1 text-left">
+                <p className="text-sm font-semibold uppercase tracking-wide">{member.name}</p>
+                <p className="text-lg font-display text-famboard-primary dark:text-sky-300">{member.points} pts</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{upcoming} chore{upcoming === 1 ? '' : 's'} waiting</p>
+              </div>
+            </button>
+          )
+        })}
+        {familyMembers.length === 0 && (
+          <div className={`${tileBaseClasses} border-dashed border-slate-300/70 bg-white/60 text-slate-500 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400`}>
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-200/80 text-2xl dark:bg-slate-700/80" aria-hidden>
+              ➕
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold uppercase tracking-wide">No members yet</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Add family members in settings to personalize the board.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
   )
 }
 
@@ -111,6 +201,7 @@ function Layout() {
           </div>
         </div>
       )}
+      <UserSwitcher />
       <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8">
         {isHydrated ? (
           <Outlet />

--- a/src/context/FamboardContext.jsx
+++ b/src/context/FamboardContext.jsx
@@ -4,6 +4,7 @@ const STORAGE_KEY = 'famboard-state-v1'
 
 const defaultData = {
   theme: 'light',
+  activeView: 'family',
   familyMembers: [
     {
       id: 'member-1',
@@ -138,6 +139,16 @@ export function FamboardProvider({ children }) {
             },
           ],
         })),
+      setActiveView: (view) =>
+        setState((prev) => {
+          if (view !== 'family' && !prev.familyMembers.some((member) => member.id === view)) {
+            return prev
+          }
+          return {
+            ...prev,
+            activeView: view,
+          }
+        }),
       updateFamilyMember: (id, updates) =>
         setState((prev) => ({
           ...prev,
@@ -152,6 +163,7 @@ export function FamboardProvider({ children }) {
           chores: prev.chores.map((chore) =>
             chore.assignedTo === id ? { ...chore, assignedTo: null } : chore,
           ),
+          activeView: prev.activeView === id ? 'family' : prev.activeView,
         })),
       addChore: (payload) =>
         setState((prev) => ({
@@ -340,6 +352,7 @@ export function FamboardProvider({ children }) {
         setState({
           ...defaultData,
           theme: state.theme,
+          activeView: 'family',
         }),
     }),
     [state.theme],

--- a/src/pages/ChoresScreen.jsx
+++ b/src/pages/ChoresScreen.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { useFamboard } from '../context/FamboardContext.jsx'
 import { launchConfetti } from '../utils/confetti.js'
 
-function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
+function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave, canManage = true }) {
   const [isEditing, setIsEditing] = useState(false)
   const [form, setForm] = useState({
     title: chore.title,
@@ -22,6 +22,12 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
       imageUrl: chore.imageUrl ?? '',
     })
   }, [chore])
+
+  useEffect(() => {
+    if (!canManage) {
+      setIsEditing(false)
+    }
+  }, [canManage])
 
   const assignedMember = familyMembers.find((member) => member.id === chore.assignedTo)
 
@@ -43,7 +49,7 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
 
   return (
     <div className="rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-sm transition hover:border-famboard-primary/60 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900/80">
-      {isEditing ? (
+      {isEditing && canManage ? (
         <form className="space-y-3" onSubmit={handleSubmit}>
           <div className="flex items-center gap-3">
             <div className="h-20 w-20 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
@@ -180,18 +186,22 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
             >
               {chore.completed ? 'Mark as not done' : 'Mark complete'}
             </button>
-            <button
-              onClick={() => setIsEditing(true)}
-              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
-            >
-              Edit
-            </button>
-            <button
-              onClick={() => onDelete(chore.id)}
-              className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
-            >
-              Delete
-            </button>
+            {canManage && (
+              <>
+                <button
+                  onClick={() => setIsEditing(true)}
+                  className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => onDelete(chore.id)}
+                  className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
+                >
+                  Delete
+                </button>
+              </>
+            )}
           </div>
         </div>
       )}
@@ -200,42 +210,28 @@ function ChoreCard({ chore, familyMembers, onToggle, onDelete, onSave }) {
 }
 
 export default function ChoresScreen() {
-  const { state, addChore, toggleChoreComplete, removeChore, updateChore } = useFamboard()
-  const { familyMembers, chores, rewards } = state
-  const [form, setForm] = useState({
-    title: '',
-    description: '',
-    assignedTo: '',
-    points: 10,
-    imageUrl: '',
-  })
+  const { state, toggleChoreComplete, removeChore, updateChore } = useFamboard()
+  const { familyMembers, chores, rewards, activeView } = state
 
-  const upcomingChores = useMemo(
-    () => chores.filter((chore) => !chore.completed),
-    [chores],
-  )
-  const completedChores = useMemo(
-    () => chores.filter((chore) => chore.completed),
-    [chores],
-  )
+  const selectedMember = activeView === 'family' ? null : familyMembers.find((member) => member.id === activeView)
+  const isMemberView = Boolean(selectedMember)
+
+  const upcomingChores = useMemo(() => {
+    return chores.filter(
+      (chore) => !chore.completed && (!isMemberView || chore.assignedTo === selectedMember.id),
+    )
+  }, [chores, isMemberView, selectedMember?.id])
+
+  const completedChores = useMemo(() => {
+    return chores.filter(
+      (chore) => chore.completed && (!isMemberView || chore.assignedTo === selectedMember.id),
+    )
+  }, [chores, isMemberView, selectedMember?.id])
 
   const totalPointsInRewards = useMemo(
     () => rewards.reduce((sum, reward) => sum + reward.cost, 0),
     [rewards],
   )
-
-  const handleCreate = (event) => {
-    event.preventDefault()
-    if (!form.title.trim()) return
-    addChore({
-      title: form.title.trim(),
-      description: form.description.trim(),
-      assignedTo: form.assignedTo || null,
-      points: Number(form.points) || 0,
-      imageUrl: form.imageUrl.trim(),
-    })
-    setForm({ title: '', description: '', assignedTo: '', points: 10, imageUrl: '' })
-  }
 
   const handleToggle = (id, wasCompleted) => {
     toggleChoreComplete(id)
@@ -251,114 +247,83 @@ export default function ChoresScreen() {
         <div className="absolute -right-16 -bottom-12 h-60 w-60 rounded-full bg-violet-400/30 blur-3xl" aria-hidden />
         <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-2xl space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">Mission control</p>
-            <h1 className="font-display text-4xl leading-tight sm:text-5xl">Organize the work, unleash the celebrations</h1>
-            <p className="text-base text-white/80">
-              Create chores, assign helpers, and mark them complete to shower the family with confetti and points.
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">
+              {isMemberView ? 'Your checklist' : 'Mission control'}
             </p>
-            <Link
-              to="/rewards"
-              className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
-            >
-              Plan reward payouts
-            </Link>
+            <h1 className="font-display text-4xl leading-tight sm:text-5xl">
+              {isMemberView ? `Let’s tackle your chores, ${selectedMember.name}!` : 'Organize the work, unleash the celebrations'}
+            </h1>
+            <p className="text-base text-white/80">
+              {isMemberView
+                ? 'Mark chores complete, watch the confetti fly, and keep earning points toward your next reward.'
+                : 'Assign helpers, track progress, and shower the family with confetti and points as chores get done.'}
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/rewards"
+                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+              >
+                {isMemberView ? 'Check rewards you can claim' : 'Plan reward payouts'}
+              </Link>
+              <Link
+                to="/settings"
+                className="inline-flex items-center justify-center rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/10"
+              >
+                Manage chores in settings
+              </Link>
+            </div>
           </div>
           <div className="grid w-full max-w-lg gap-4 sm:grid-cols-2">
             <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Chores in queue</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
+                {isMemberView ? 'Chores waiting for you' : 'Chores in queue'}
+              </p>
               <p className="mt-2 text-3xl font-bold">{upcomingChores.length}</p>
-              <p className="text-xs text-white/70">Ready for a helping hand.</p>
+              <p className="text-xs text-white/70">
+                {isMemberView ? 'Ready when you are.' : 'Ready for a helping hand.'}
+              </p>
             </div>
             <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Completed</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
+                {isMemberView ? 'Your completed chores' : 'Completed'}
+              </p>
               <p className="mt-2 text-3xl font-bold">{completedChores.length}</p>
-              <p className="text-xs text-white/70">Confetti-worthy moments logged.</p>
+              <p className="text-xs text-white/70">
+                {isMemberView ? 'Confetti-worthy wins already logged.' : 'Confetti-worthy moments logged.'}
+              </p>
             </div>
             <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur sm:col-span-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Reward wishlist value</p>
-              <p className="mt-2 text-3xl font-bold">{totalPointsInRewards} pts</p>
-              <p className="text-xs text-white/70">Goal points to unlock every prize.</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
+                {isMemberView ? 'Points you can spend' : 'Reward wishlist value'}
+              </p>
+              <p className="mt-2 text-3xl font-bold">
+                {isMemberView ? selectedMember.points : `${totalPointsInRewards} pts`}
+              </p>
+              <p className="text-xs text-white/70">
+                {isMemberView
+                  ? 'Head to the rewards shelf when you’re ready to celebrate.'
+                  : 'Goal points to unlock every prize.'}
+              </p>
             </div>
           </div>
         </div>
       </section>
 
       <section className="rounded-3xl bg-white/85 p-8 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
-        <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div>
-            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Create a chore</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">Define what done looks like and who’s on duty.</p>
-          </div>
-          <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
-            Builder tools
-          </span>
-        </header>
-        <form onSubmit={handleCreate} className="mt-6 grid gap-5 md:grid-cols-2">
-          <div className="space-y-2 md:col-span-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Chore title</label>
-            <input
-              required
-              value={form.title}
-              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-              placeholder="Tidy the playroom"
-            />
-          </div>
-          <div className="space-y-2 md:col-span-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Description</label>
-            <textarea
-              value={form.description}
-              onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
-              className="min-h-[140px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-              placeholder="List the steps so everyone knows what finished looks like."
-            />
-          </div>
-          <div className="space-y-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Picture URL</label>
-            <input
-              value={form.imageUrl}
-              onChange={(event) => setForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
-              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-              placeholder="https://..."
-            />
-            <p className="text-xs text-slate-400 dark:text-slate-500">
-              Add a visual clue so kids remember what to do.
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="max-w-2xl space-y-2">
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Need a new chore?</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              All chore creation and editing tools now live in the admin settings so grown-ups can manage the board in one place.
             </p>
           </div>
-          <div className="space-y-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Assign to</label>
-            <select
-              value={form.assignedTo}
-              onChange={(event) => setForm((prev) => ({ ...prev, assignedTo: event.target.value }))}
-              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-            >
-              <option value="">Unassigned</option>
-              {familyMembers.map((member) => (
-                <option key={member.id} value={member.id}>
-                  {member.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="space-y-2">
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Points</label>
-            <input
-              type="number"
-              min="0"
-              value={form.points}
-              onChange={(event) => setForm((prev) => ({ ...prev, points: event.target.value }))}
-              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-            />
-          </div>
-          <div className="md:col-span-2">
-            <button
-              type="submit"
-              className="w-full rounded-full bg-emerald-500 px-6 py-3 text-lg font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-emerald-600 focus:outline-none focus:ring-4 focus:ring-emerald-300/70"
-            >
-              Add chore
-            </button>
-          </div>
-        </form>
+          <Link
+            to="/settings"
+            className="inline-flex items-center justify-center rounded-full bg-famboard-primary px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-dark focus:outline-none focus:ring-2 focus:ring-famboard-accent focus:ring-offset-2"
+          >
+            Go to admin settings
+          </Link>
+        </div>
       </section>
 
       <section className="space-y-6">
@@ -368,13 +333,15 @@ export default function ChoresScreen() {
             <p className="text-sm text-slate-500 dark:text-slate-400">Tap a card to celebrate a job well done or edit the details.</p>
           </div>
           <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
-            {chores.length} total
+            {isMemberView ? upcomingChores.length + completedChores.length : chores.length} total
           </span>
         </header>
         <div className="grid gap-5 xl:grid-cols-2">
-          {chores.length === 0 && (
+          {(isMemberView ? upcomingChores.length + completedChores.length === 0 : chores.length === 0) && (
             <p className="rounded-3xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
-              No chores yet. Add one above to kick things off.
+              {isMemberView
+                ? 'No chores assigned to you yet. Check back soon!'
+                : 'No chores yet. Add new tasks from the settings page to kick things off.'}
             </p>
           )}
           {[...upcomingChores, ...completedChores].map((chore) => (
@@ -385,6 +352,7 @@ export default function ChoresScreen() {
               onToggle={handleToggle}
               onDelete={removeChore}
               onSave={updateChore}
+              canManage={!isMemberView}
             />
           ))}
         </div>

--- a/src/pages/HomeScreen.jsx
+++ b/src/pages/HomeScreen.jsx
@@ -5,36 +5,50 @@ import { launchConfetti } from '../utils/confetti.js'
 
 export default function HomeScreen() {
   const { state, toggleChoreComplete } = useFamboard()
-  const { familyMembers, chores, rewards } = state
+  const { familyMembers, chores, rewards, activeView } = state
 
-  const upcomingChores = useMemo(
-    () => chores.filter((chore) => !chore.completed),
-    [chores],
-  )
-  const completedChores = useMemo(
-    () =>
-      chores
-        .filter((chore) => chore.completed)
-        .sort((a, b) => {
-          if (!a.completedAt) return 1
-          if (!b.completedAt) return -1
-          return new Date(b.completedAt) - new Date(a.completedAt)
-        }),
-    [chores],
-  )
+  const selectedMember = activeView === 'family' ? null : familyMembers.find((member) => member.id === activeView)
+  const isMemberView = Boolean(selectedMember)
 
-  const availableRewards = useMemo(
-    () => [...rewards].sort((a, b) => a.cost - b.cost),
-    [rewards],
-  )
+  const upcomingChores = useMemo(() => {
+    return chores
+      .filter((chore) => !chore.completed)
+      .filter((chore) => (isMemberView ? chore.assignedTo === selectedMember.id : true))
+  }, [chores, isMemberView, selectedMember?.id])
 
-  const totalPoints = useMemo(
-    () => familyMembers.reduce((sum, member) => sum + member.points, 0),
-    [familyMembers],
-  )
+  const completedChores = useMemo(() => {
+    return chores
+      .filter((chore) => chore.completed)
+      .filter((chore) => (isMemberView ? chore.assignedTo === selectedMember.id : true))
+      .sort((a, b) => {
+        if (!a.completedAt) return 1
+        if (!b.completedAt) return -1
+        return new Date(b.completedAt) - new Date(a.completedAt)
+      })
+  }, [chores, isMemberView, selectedMember?.id])
 
-  const totalChores = chores.length
+  const availableRewards = useMemo(() => {
+    const sorted = [...rewards].sort((a, b) => a.cost - b.cost)
+    if (!isMemberView) {
+      return sorted
+    }
+    return sorted.filter((reward) => reward.cost === 0 || reward.cost <= selectedMember.points)
+  }, [rewards, isMemberView, selectedMember?.points])
+
+  const totalPoints = useMemo(() => {
+    if (isMemberView) {
+      return selectedMember.points
+    }
+    return familyMembers.reduce((sum, member) => sum + member.points, 0)
+  }, [familyMembers, isMemberView, selectedMember?.points])
+
+  const totalChores = isMemberView ? upcomingChores.length + completedChores.length : chores.length
   const completedCount = completedChores.length
+  const upcomingCount = upcomingChores.length
+  const rewardsReadyCount = availableRewards.length
+  const otherMembers = isMemberView
+    ? familyMembers.filter((member) => member.id !== selectedMember.id)
+    : familyMembers
 
   const handleToggleChore = (chore) => {
     toggleChoreComplete(chore.id)
@@ -48,69 +62,124 @@ export default function HomeScreen() {
       <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-famboard-primary via-sky-500 to-emerald-500 p-8 text-white shadow-xl">
         <div className="absolute -left-32 top-10 h-60 w-60 rounded-full bg-white/10 blur-3xl" aria-hidden />
         <div className="absolute -right-10 -bottom-10 h-64 w-64 rounded-full bg-emerald-400/30 blur-3xl" aria-hidden />
-        <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
-          <div className="max-w-2xl space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">Famboard HQ</p>
-            <h1 className="font-display text-4xl leading-tight sm:text-5xl">Celebrate progress and spark more high-fives</h1>
-            <p className="text-base text-white/80">
-              Glance at the latest wins, keep chores flowing, and hype the next big reward moment for your crew.
-            </p>
-            <div className="flex flex-wrap gap-3">
-              <Link
-                to="/chores"
-                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
-              >
-                View chore board
-              </Link>
-              <Link
-                to="/rewards"
-                className="inline-flex items-center justify-center rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/10"
-              >
-                Browse rewards
-              </Link>
+        {isMemberView ? (
+          <div className="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-start gap-5">
+              <div className="h-24 w-24 shrink-0 overflow-hidden rounded-4xl border border-white/50 bg-white/10 shadow-inner backdrop-blur">
+                {selectedMember.imageUrl ? (
+                  <img src={selectedMember.imageUrl} alt={selectedMember.name} className="h-full w-full object-cover" />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-4xl">😊</div>
+                )}
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">Welcome back</p>
+                <h1 className="font-display text-4xl leading-tight sm:text-5xl">Hi {selectedMember.name}! Ready to make today awesome?</h1>
+                <p className="text-base text-white/80">
+                  Check what’s on your list, see what you’ve finished, and cash in rewards you can afford right now.
+                </p>
+                <div className="flex flex-wrap gap-3">
+                  <Link
+                    to="/chores"
+                    className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+                  >
+                    View your chores
+                  </Link>
+                  <Link
+                    to="/rewards"
+                    className="inline-flex items-center justify-center rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/10"
+                  >
+                    Explore rewards
+                  </Link>
+                </div>
+              </div>
+            </div>
+            <div className="grid w-full max-w-md gap-4 sm:grid-cols-2">
+              <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points ready</p>
+                <p className="mt-2 text-3xl font-bold">{totalPoints}</p>
+                <p className="text-xs text-white/70">Save up for something epic.</p>
+              </div>
+              <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Chores done</p>
+                <p className="mt-2 text-3xl font-bold">{completedCount}</p>
+                <p className="text-xs text-white/70">Out of {totalChores} assigned to you.</p>
+              </div>
+              <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur sm:col-span-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Rewards you can redeem</p>
+                <p className="mt-2 text-3xl font-bold">{rewardsReadyCount}</p>
+                <p className="text-xs text-white/70">Check the rewards tab to celebrate.</p>
+              </div>
             </div>
           </div>
-          <div className="grid w-full max-w-md gap-4 sm:grid-cols-2">
-            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Family members</p>
-              <p className="mt-2 text-3xl font-bold">{familyMembers.length}</p>
-              <p className="text-xs text-white/70">Cheering each other on.</p>
+        ) : (
+          <div className="relative flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-2xl space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/70">Famboard HQ</p>
+              <h1 className="font-display text-4xl leading-tight sm:text-5xl">Celebrate progress and spark more high-fives</h1>
+              <p className="text-base text-white/80">
+                Glance at the latest wins, keep chores flowing, and hype the next big reward moment for your crew.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  to="/chores"
+                  className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+                >
+                  View chore board
+                </Link>
+                <Link
+                  to="/rewards"
+                  className="inline-flex items-center justify-center rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/10"
+                >
+                  Browse rewards
+                </Link>
+              </div>
             </div>
-            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points in play</p>
-              <p className="mt-2 text-3xl font-bold">{totalPoints}</p>
-              <p className="text-xs text-white/70">Ready for epic rewards.</p>
-            </div>
-            <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur sm:col-span-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Chores completed</p>
-              <p className="mt-2 text-3xl font-bold">{completedCount}</p>
-              <p className="text-xs text-white/70">Out of {totalChores} total chores.</p>
+            <div className="grid w-full max-w-md gap-4 sm:grid-cols-2">
+              <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Family members</p>
+                <p className="mt-2 text-3xl font-bold">{familyMembers.length}</p>
+                <p className="text-xs text-white/70">Cheering each other on.</p>
+              </div>
+              <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur">
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points in play</p>
+                <p className="mt-2 text-3xl font-bold">{totalPoints}</p>
+                <p className="text-xs text-white/70">Ready for epic rewards.</p>
+              </div>
+              <div className="rounded-2xl bg-white/15 p-4 shadow-inner backdrop-blur sm:col-span-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Chores completed</p>
+                <p className="mt-2 text-3xl font-bold">{completedCount}</p>
+                <p className="text-xs text-white/70">Out of {totalChores} total chores.</p>
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </section>
 
       <section className="space-y-4">
         <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>
-            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Family spotlight</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">See everyone’s momentum and encourage the next victory lap.</p>
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">
+              {isMemberView ? 'Your crew' : 'Family spotlight'}
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {isMemberView
+                ? 'See how you stack up and cheer on the rest of the family.'
+                : 'See everyone’s momentum and encourage the next victory lap.'}
+            </p>
           </div>
           <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
             {familyMembers.length} member{familyMembers.length === 1 ? '' : 's'}
           </span>
         </header>
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-          {familyMembers.map((member) => (
-            <div
-              key={member.id}
-              className="group relative overflow-hidden rounded-3xl border border-transparent bg-white/90 p-6 shadow-card transition hover:-translate-y-1 hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80"
-            >
+        {isMemberView ? (
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,_2fr)_minmax(0,_1fr)]">
+            <div className="group relative overflow-hidden rounded-3xl border border-transparent bg-white/90 p-6 shadow-card transition hover:-translate-y-1 hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80">
               <div className="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full bg-famboard-primary/10 blur-2xl transition group-hover:bg-famboard-primary/20" aria-hidden />
               <div className="flex items-center gap-4">
                 <div className="h-20 w-20 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
-                  {member.imageUrl ? (
-                    <img src={member.imageUrl} alt={member.name} className="h-full w-full object-cover" />
+                  {selectedMember.imageUrl ? (
+                    <img src={selectedMember.imageUrl} alt={selectedMember.name} className="h-full w-full object-cover" />
                   ) : (
                     <div className="flex h-full w-full items-center justify-center text-3xl">😊</div>
                   )}
@@ -119,37 +188,89 @@ export default function HomeScreen() {
                   <div className="flex items-start justify-between">
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Point stash</p>
-                      <p className="font-display text-4xl text-famboard-primary dark:text-sky-300">{member.points}</p>
+                      <p className="font-display text-4xl text-famboard-primary dark:text-sky-300">{selectedMember.points}</p>
                     </div>
                     <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-medium text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
-                      {member.name}
+                      {selectedMember.name}
                     </span>
                   </div>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">Keep it up! Rewards are just a few chores away.</p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    {upcomingCount === 0
+                      ? 'No chores waiting—enjoy a well-earned break!'
+                      : `${upcomingCount} chore${upcomingCount === 1 ? '' : 's'} ready for your magic touch.`}
+                  </p>
                 </div>
               </div>
             </div>
-          ))}
-          {familyMembers.length === 0 && (
-            <p className="rounded-3xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
-              Add your crew in settings to start tracking their progress.
-            </p>
-          )}
-        </div>
+            <div className="space-y-3 rounded-3xl border border-white/60 bg-white/90 p-5 shadow-inner dark:border-slate-700 dark:bg-slate-900/70">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Other members</h3>
+              {otherMembers.length === 0 && (
+                <p className="text-sm text-slate-500 dark:text-slate-400">You’re the only one here so far—ask an adult to add more family in settings.</p>
+              )}
+              <ul className="space-y-2">
+                {otherMembers.map((member) => (
+                  <li key={member.id} className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-300">
+                    <span>{member.name}</span>
+                    <span className="font-semibold text-famboard-primary dark:text-sky-300">{member.points} pts</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {otherMembers.map((member) => (
+              <div
+                key={member.id}
+                className="group relative overflow-hidden rounded-3xl border border-transparent bg-white/90 p-6 shadow-card transition hover:-translate-y-1 hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80"
+              >
+                <div className="pointer-events-none absolute -right-10 -top-10 h-28 w-28 rounded-full bg-famboard-primary/10 blur-2xl transition group-hover:bg-famboard-primary/20" aria-hidden />
+                <div className="flex items-center gap-4">
+                  <div className="h-20 w-20 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+                    {member.imageUrl ? (
+                      <img src={member.imageUrl} alt={member.name} className="h-full w-full object-cover" />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-3xl">😊</div>
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-2">
+                    <div className="flex items-start justify-between">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Point stash</p>
+                        <p className="font-display text-4xl text-famboard-primary dark:text-sky-300">{member.points}</p>
+                      </div>
+                      <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-medium text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
+                        {member.name}
+                      </span>
+                    </div>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">Keep it up! Rewards are just a few chores away.</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+            {familyMembers.length === 0 && (
+              <p className="rounded-3xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
+                Add your crew in settings to start tracking their progress.
+              </p>
+            )}
+          </div>
+        )}
       </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
         <div className="rounded-3xl bg-white/85 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
           <header className="mb-4 flex items-center justify-between">
-            <h2 className="font-display text-2xl text-slate-800 dark:text-white">Upcoming chores</h2>
+            <h2 className="font-display text-2xl text-slate-800 dark:text-white">
+              {isMemberView ? 'Your upcoming chores' : 'Upcoming chores'}
+            </h2>
             <span className="rounded-full bg-famboard-accent/20 px-3 py-1 text-sm font-semibold text-famboard-dark dark:bg-amber-400/20 dark:text-amber-200">
-              {upcomingChores.length}
+              {upcomingCount}
             </span>
           </header>
           <div className="space-y-3">
             {upcomingChores.length === 0 && (
               <p className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 p-4 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-slate-400">
-                Nothing on the list! Enjoy a break together.
+                {isMemberView ? 'No chores on your list right now. Enjoy some downtime!' : 'Nothing on the list! Enjoy a break together.'}
               </p>
             )}
             {upcomingChores.map((chore) => {
@@ -170,7 +291,12 @@ export default function HomeScreen() {
                     <p className="font-semibold text-slate-800 dark:text-white">{chore.title}</p>
                     <p className="text-sm text-slate-500 dark:text-slate-400">{chore.description}</p>
                     <p className="pt-1 text-xs font-medium uppercase tracking-wide text-slate-400">
-                      {assigned ? `Assigned to ${assigned.name}` : 'Unassigned'} · {chore.points} pts
+                      {assigned
+                        ? isMemberView
+                          ? 'Assigned to you'
+                          : `Assigned to ${assigned.name}`
+                        : 'Unassigned'}{' '}
+                      · {chore.points} pts
                     </p>
                   </div>
                   <button
@@ -187,15 +313,19 @@ export default function HomeScreen() {
 
         <div className="rounded-3xl bg-white/85 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
           <header className="mb-4 flex items-center justify-between">
-            <h2 className="font-display text-2xl text-slate-800 dark:text-white">Completed chores</h2>
+            <h2 className="font-display text-2xl text-slate-800 dark:text-white">
+              {isMemberView ? 'Chores you crushed' : 'Completed chores'}
+            </h2>
             <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-sm font-semibold text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-200">
-              {completedChores.length}
+              {completedCount}
             </span>
           </header>
           <div className="space-y-3">
             {completedChores.length === 0 && (
               <p className="rounded-2xl border border-dashed border-emerald-300/60 bg-white/60 p-4 text-sm text-slate-500 shadow-inner dark:border-emerald-600/60 dark:bg-slate-900/60 dark:text-slate-400">
-                Finish chores to see them shine here.
+                {isMemberView
+                  ? 'Complete a chore to see it sparkle here.'
+                  : 'Finish chores to see them shine here.'}
               </p>
             )}
             {completedChores.map((chore) => {
@@ -216,7 +346,12 @@ export default function HomeScreen() {
                     <p className="font-semibold text-emerald-700 dark:text-emerald-200">{chore.title}</p>
                     <p className="text-sm text-slate-500 dark:text-slate-400">{chore.description}</p>
                     <p className="pt-1 text-xs font-medium uppercase tracking-wide text-slate-400">
-                      {assigned ? `By ${assigned.name}` : 'Unassigned'} · {chore.points} pts
+                      {assigned
+                        ? isMemberView
+                          ? 'Completed by you'
+                          : `By ${assigned.name}`
+                        : 'Unassigned'}{' '}
+                      · {chore.points} pts
                     </p>
                   </div>
                   <button
@@ -235,11 +370,17 @@ export default function HomeScreen() {
       <section className="rounded-3xl bg-white/85 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
         <header className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Reward store preview</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">Get inspired by what’s waiting once the points pile up.</p>
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">
+              {isMemberView ? 'Rewards ready for you' : 'Reward store preview'}
+            </h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {isMemberView
+                ? 'These are the rewards you can afford right now. Keep earning to unlock even more!'
+                : 'Get inspired by what’s waiting once the points pile up.'}
+            </p>
           </div>
           <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-semibold text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
-            {availableRewards.length} reward{availableRewards.length === 1 ? '' : 's'}
+            {rewardsReadyCount} reward{rewardsReadyCount === 1 ? '' : 's'}
           </span>
         </header>
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -266,7 +407,9 @@ export default function HomeScreen() {
           ))}
           {availableRewards.length === 0 && (
             <p className="rounded-3xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
-              Add rewards in the Rewards tab to motivate the crew!
+              {isMemberView
+                ? 'Keep finishing chores to unlock your next reward!'
+                : 'Add rewards in the Rewards tab to motivate the crew!'}
             </p>
           )}
         </div>

--- a/src/pages/RewardsScreen.jsx
+++ b/src/pages/RewardsScreen.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useFamboard } from '../context/FamboardContext.jsx'
 
-function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
+function RewardCard({ reward, members, onRedeem, onDelete, onSave, canManage = true }) {
   const [selectedMember, setSelectedMember] = useState(members[0]?.id ?? '')
   const [isEditing, setIsEditing] = useState(false)
   const [form, setForm] = useState({
@@ -42,6 +42,12 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
     }
   }, [members, selectedMember])
 
+  useEffect(() => {
+    if (!canManage) {
+      setIsEditing(false)
+    }
+  }, [canManage])
+
   const canRedeem = selectedMember
     ? (members.find((member) => member.id === selectedMember)?.points ?? 0) >= reward.cost
     : false
@@ -60,7 +66,7 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
   return (
     <div className="group relative overflow-hidden rounded-3xl border border-transparent bg-white/90 p-6 shadow-card transition hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80">
       <div className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full bg-famboard-primary/10 blur-2xl transition group-hover:bg-famboard-primary/20" aria-hidden />
-      {isEditing ? (
+      {isEditing && canManage ? (
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div className="flex items-center gap-3">
             <div className="h-20 w-20 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
@@ -168,18 +174,24 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
             <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Redeem for
             </label>
-            <select
-              value={selectedMember}
-              onChange={(event) => setSelectedMember(event.target.value)}
-              className="w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-            >
-              {members.length === 0 && <option value="">Add family members first</option>}
-              {members.map((member) => (
-                <option key={member.id} value={member.id}>
-                  {member.name} · {member.points} pts
-                </option>
-              ))}
-            </select>
+            {members.length <= 1 ? (
+              <div className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm shadow-inner dark:border-slate-700 dark:bg-slate-900">
+                {members.length === 0 ? 'Add family members first' : `${members[0].name} · ${members[0].points} pts`}
+              </div>
+            ) : (
+              <select
+                value={selectedMember}
+                onChange={(event) => setSelectedMember(event.target.value)}
+                className="w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              >
+                {members.length === 0 && <option value="">Add family members first</option>}
+                {members.map((member) => (
+                  <option key={member.id} value={member.id}>
+                    {member.name} · {member.points} pts
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
           {selectedMemberData && (
             <div className="space-y-1">
@@ -209,18 +221,22 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
             >
               Redeem reward
             </button>
-            <button
-              onClick={() => setIsEditing(true)}
-              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
-            >
-              Edit
-            </button>
-            <button
-              onClick={() => onDelete(reward.id)}
-              className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
-            >
-              Delete
-            </button>
+            {canManage && (
+              <>
+                <button
+                  onClick={() => setIsEditing(true)}
+                  className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => onDelete(reward.id)}
+                  className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
+                >
+                  Delete
+                </button>
+              </>
+            )}
           </div>
           {!canRedeem && selectedMember && (
             <p className="text-xs font-medium text-rose-500 dark:text-rose-300">
@@ -236,20 +252,27 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave }) {
 
 export default function RewardsScreen() {
   const { state, redeemReward, removeReward, updateReward } = useFamboard()
-  const { familyMembers, rewards } = state
+  const { familyMembers, rewards, activeView } = state
 
-  const totalPoints = useMemo(
-    () => familyMembers.reduce((sum, member) => sum + member.points, 0),
-    [familyMembers],
-  )
+  const selectedMember = activeView === 'family' ? null : familyMembers.find((member) => member.id === activeView)
+  const isMemberView = Boolean(selectedMember)
 
-  const readyToRedeem = useMemo(
-    () =>
-      rewards.filter((reward) =>
-        familyMembers.some((member) => reward.cost === 0 || member.points >= reward.cost),
-      ).length,
-    [familyMembers, rewards],
-  )
+  const totalPoints = useMemo(() => {
+    if (isMemberView) {
+      return selectedMember.points
+    }
+    return familyMembers.reduce((sum, member) => sum + member.points, 0)
+  }, [familyMembers, isMemberView, selectedMember?.points])
+
+  const readyToRedeem = useMemo(() => {
+    if (isMemberView) {
+      if (!selectedMember) return 0
+      return rewards.filter((reward) => reward.cost === 0 || selectedMember.points >= reward.cost).length
+    }
+    return rewards.filter((reward) =>
+      familyMembers.some((member) => reward.cost === 0 || member.points >= reward.cost),
+    ).length
+  }, [familyMembers, isMemberView, rewards, selectedMember])
 
   const averageCost = useMemo(() => {
     if (rewards.length === 0) return 0
@@ -258,11 +281,11 @@ export default function RewardsScreen() {
   }, [rewards])
 
   const topMember = useMemo(() => {
-    if (familyMembers.length === 0) return null
-    return familyMembers.reduce((prev, current) =>
-      current.points > prev.points ? current : prev,
-    )
-  }, [familyMembers])
+    if (isMemberView || familyMembers.length === 0) return null
+    return familyMembers.reduce((prev, current) => (current.points > prev.points ? current : prev))
+  }, [familyMembers, isMemberView])
+
+  const membersForCards = isMemberView ? (selectedMember ? [selectedMember] : []) : familyMembers
 
   return (
     <div className="space-y-10 pb-16">
@@ -271,51 +294,78 @@ export default function RewardsScreen() {
         <div className="absolute -right-10 -bottom-10 h-60 w-60 rounded-full bg-emerald-400/20 blur-3xl" aria-hidden />
         <div className="relative space-y-8">
           <div className="max-w-3xl space-y-3">
-            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">Celebration station</p>
-            <h2 className="font-display text-4xl leading-tight sm:text-5xl">Turn points into unforgettable family moments</h2>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-white/70">
+              {isMemberView ? 'Celebrate your wins' : 'Celebration station'}
+            </p>
+            <h2 className="font-display text-4xl leading-tight sm:text-5xl">
+              {isMemberView
+                ? `Ready to redeem, ${selectedMember.name}?`
+                : 'Turn points into unforgettable family moments'}
+            </h2>
             <p className="text-base text-white/80">
-              Browse the current reward shelf, see who is closest to cashing in, and cheer everyone on.
+              {isMemberView
+                ? 'See which rewards are within reach and decide how to spend your hard-earned points.'
+                : 'Browse the current reward shelf, see who is closest to cashing in, and cheer everyone on.'}
             </p>
           </div>
           <div className="grid gap-4 md:grid-cols-3">
             <div className="rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Rewards ready to redeem</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
+                {isMemberView ? 'Rewards you can redeem' : 'Rewards ready to redeem'}
+              </p>
               <p className="mt-2 text-3xl font-bold">{readyToRedeem}</p>
-              <p className="text-xs text-white/70">Family treats are within reach right now.</p>
+              <p className="text-xs text-white/70">
+                {isMemberView ? 'Pick a favorite and celebrate your effort.' : 'Family treats are within reach right now.'}
+              </p>
             </div>
             <div className="rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points in circulation</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
+                {isMemberView ? 'Your point balance' : 'Points in circulation'}
+              </p>
               <p className="mt-2 text-3xl font-bold">{totalPoints}</p>
-              <p className="text-xs text-white/70">Earned by your hard-working crew.</p>
+              <p className="text-xs text-white/70">
+                {isMemberView
+                  ? 'Spend them now or keep saving for something big.'
+                  : 'Earned by your hard-working crew.'}
+              </p>
             </div>
             <div className="rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur">
               <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Average reward cost</p>
               <p className="mt-2 text-3xl font-bold">{averageCost} pts</p>
-              <p className="text-xs text-white/70">Plan chores that match the excitement.</p>
+              <p className="text-xs text-white/70">
+                {isMemberView
+                  ? 'Aim for rewards that match your balance or keep stacking points.'
+                  : 'Plan chores that match the excitement.'}
+              </p>
             </div>
           </div>
-          {topMember && (
+          {isMemberView ? (
+            <Link
+              to="/chores"
+              className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
+            >
+              Earn more points on the chore board
+            </Link>
+          ) : (
             <div className="flex flex-col gap-4 rounded-2xl bg-white/10 p-4 shadow-inner backdrop-blur sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points leader</p>
-                <p className="text-lg font-semibold">{topMember.name}</p>
-                <p className="text-sm text-white/70">{topMember.points} points earned and ready to celebrate.</p>
+                {topMember ? (
+                  <>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Points leader</p>
+                    <p className="text-lg font-semibold">{topMember.name}</p>
+                    <p className="text-sm text-white/70">{topMember.points} points earned and ready to celebrate.</p>
+                  </>
+                ) : (
+                  <p className="text-sm text-white/80">Add family members to start tracking who’s closest to a reward.</p>
+                )}
               </div>
               <Link
                 to="/settings"
                 className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
               >
-                Create new rewards in settings
+                Manage rewards in settings
               </Link>
             </div>
-          )}
-          {!topMember && (
-            <Link
-              to="/settings"
-              className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-famboard-primary shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-accent hover:text-famboard-dark"
-            >
-              Head to settings to create your first reward
-            </Link>
           )}
         </div>
       </section>
@@ -323,32 +373,41 @@ export default function RewardsScreen() {
       <section className="space-y-6">
         <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>
-            <h3 className="font-display text-3xl text-slate-800 dark:text-white">Reward shelf</h3>
+            <h3 className="font-display text-3xl text-slate-800 dark:text-white">
+              {isMemberView ? 'Your reward shelf' : 'Reward shelf'}
+            </h3>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Pick who redeems the reward and watch their points sparkle away in real time.
+              {isMemberView
+                ? 'Choose a reward to redeem with your points. Ask a grown-up if you need help.'
+                : 'Pick who redeems the reward and watch their points sparkle away in real time.'}
             </p>
           </div>
-          <Link
-            to="/settings"
-            className="inline-flex items-center justify-center rounded-full border border-famboard-primary/60 px-4 py-2 text-sm font-semibold text-famboard-primary transition hover:bg-famboard-primary hover:text-white"
-          >
-            Manage rewards in settings
-          </Link>
+          {!isMemberView && (
+            <Link
+              to="/settings"
+              className="inline-flex items-center justify-center rounded-full border border-famboard-primary/60 px-4 py-2 text-sm font-semibold text-famboard-primary transition hover:bg-famboard-primary hover:text-white"
+            >
+              Manage rewards in settings
+            </Link>
+          )}
         </header>
         <div className="grid gap-5 lg:grid-cols-2">
           {rewards.length === 0 && (
             <p className="rounded-3xl border border-dashed border-slate-300/80 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/80 dark:bg-slate-900/70 dark:text-slate-400">
-              The shelf is empty—visit the settings admin page to dream up your first reward.
+              {isMemberView
+                ? 'No rewards available yet—check back after an adult adds some in settings.'
+                : 'The shelf is empty—visit the settings admin page to dream up your first reward.'}
             </p>
           )}
           {rewards.map((reward) => (
             <RewardCard
               key={reward.id}
               reward={reward}
-              members={familyMembers}
+              members={membersForCards}
               onRedeem={redeemReward}
               onDelete={removeReward}
               onSave={updateReward}
+              canManage={!isMemberView}
             />
           ))}
         </div>

--- a/src/pages/SettingsScreen.jsx
+++ b/src/pages/SettingsScreen.jsx
@@ -194,6 +194,170 @@ function RewardAdminCard({ reward, onSave, onRemove }) {
   )
 }
 
+function ChoreAdminCard({ chore, members, onSave, onRemove }) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [form, setForm] = useState({
+    title: chore.title,
+    description: chore.description,
+    assignedTo: chore.assignedTo ?? '',
+    points: chore.points,
+    imageUrl: chore.imageUrl ?? '',
+  })
+
+  useEffect(() => {
+    setForm({
+      title: chore.title,
+      description: chore.description,
+      assignedTo: chore.assignedTo ?? '',
+      points: chore.points,
+      imageUrl: chore.imageUrl ?? '',
+    })
+  }, [chore])
+
+  const assignedMember = members.find((member) => member.id === chore.assignedTo)
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    onSave(chore.id, {
+      title: form.title.trim() || chore.title,
+      description: form.description.trim(),
+      assignedTo: form.assignedTo || null,
+      points: Number(form.points) || 0,
+      imageUrl: form.imageUrl.trim(),
+    })
+    setIsEditing(false)
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200/60 bg-white/90 p-5 shadow-sm transition hover:border-famboard-primary/60 hover:shadow-lg dark:border-slate-700 dark:bg-slate-900/80">
+      {isEditing ? (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="h-16 w-16 overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-600 dark:bg-slate-800">
+              {form.imageUrl ? (
+                <img src={form.imageUrl} alt={form.title} className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-2xl">🧹</div>
+              )}
+            </div>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Update the title, picture, or assignment for this chore.
+            </p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Chore title</label>
+            <input
+              value={form.title}
+              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Description</label>
+            <textarea
+              value={form.description}
+              onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+              rows={3}
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Assign to</label>
+              <select
+                value={form.assignedTo}
+                onChange={(event) => setForm((prev) => ({ ...prev, assignedTo: event.target.value }))}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              >
+                <option value="">Unassigned</option>
+                {members.map((member) => (
+                  <option key={member.id} value={member.id}>
+                    {member.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Points</label>
+              <input
+                type="number"
+                min="0"
+                value={form.points}
+                onChange={(event) => setForm((prev) => ({ ...prev, points: event.target.value }))}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              />
+            </div>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Picture URL</label>
+            <input
+              value={form.imageUrl}
+              onChange={(event) => setForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+              placeholder="https://..."
+              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            />
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="submit"
+              className="flex-1 rounded-full bg-famboard-primary px-4 py-2 text-sm font-semibold text-white shadow focus:outline-none focus:ring-2 focus:ring-famboard-accent focus:ring-offset-2"
+            >
+              Save chore
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsEditing(false)}
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex items-start gap-4">
+            <div className="h-20 w-20 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
+              {chore.imageUrl ? (
+                <img src={chore.imageUrl} alt={chore.title} className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-3xl">🧽</div>
+              )}
+            </div>
+            <div className="flex-1 space-y-2">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-800 dark:text-white">{chore.title}</h3>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">{chore.description || 'Add a description to guide helpers.'}</p>
+                </div>
+                <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-sm font-semibold text-famboard-primary dark:bg-sky-400/10 dark:text-sky-200">
+                  {chore.points} pts
+                </span>
+              </div>
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                {assignedMember ? `Assigned to ${assignedMember.name}` : 'Unassigned'}
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              onClick={() => setIsEditing(true)}
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Edit chore
+            </button>
+            <button
+              onClick={() => onRemove(chore.id)}
+              className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function SettingsScreen() {
   const {
     state,
@@ -203,16 +367,26 @@ export default function SettingsScreen() {
     addReward,
     updateReward,
     removeReward,
+    addChore,
+    updateChore,
+    removeChore,
     setTheme,
     resetAll,
   } = useFamboard()
-  const { familyMembers, rewards, theme } = state
+  const { familyMembers, rewards, chores, theme } = state
   const [memberName, setMemberName] = useState('')
   const [memberImage, setMemberImage] = useState('')
   const [rewardForm, setRewardForm] = useState({
     title: '',
     description: '',
     cost: 20,
+    imageUrl: '',
+  })
+  const [choreForm, setChoreForm] = useState({
+    title: '',
+    description: '',
+    assignedTo: '',
+    points: 10,
     imageUrl: '',
   })
 
@@ -269,6 +443,28 @@ export default function SettingsScreen() {
       imageUrl: rewardForm.imageUrl.trim(),
     })
     setRewardForm({ title: '', description: '', cost: 20, imageUrl: '' })
+  }
+
+  const handleCreateChore = (event) => {
+    event.preventDefault()
+    if (!choreForm.title.trim()) return
+    addChore({
+      title: choreForm.title.trim(),
+      description: choreForm.description.trim(),
+      assignedTo: choreForm.assignedTo || null,
+      points: Number(choreForm.points) || 0,
+      imageUrl: choreForm.imageUrl.trim(),
+    })
+    setChoreForm({ title: '', description: '', assignedTo: '', points: 10, imageUrl: '' })
+  }
+
+  const handleRemoveChore = (id) => {
+    if (
+      typeof window === 'undefined' ||
+      window.confirm('Remove this chore? Kids will no longer see it on their lists.')
+    ) {
+      removeChore(id)
+    }
   }
 
   return (
@@ -370,6 +566,94 @@ export default function SettingsScreen() {
           {familyMembers.length === 0 && (
             <p className="text-sm text-slate-500 dark:text-slate-400">
               Add your family members above to start tracking points.
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-3xl bg-white/85 p-8 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-2xl space-y-2">
+            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Chore workshop</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Create new chores, adjust assignments, and remove tasks that have run their course. Kids will see updates instantly in their view.
+            </p>
+          </div>
+          <p className="rounded-full bg-famboard-primary/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+            Admin tools
+          </p>
+        </div>
+        <form onSubmit={handleCreateChore} className="mt-6 grid gap-5 md:grid-cols-2">
+          <div className="space-y-1 md:col-span-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Chore title</label>
+            <input
+              value={choreForm.title}
+              onChange={(event) => setChoreForm((prev) => ({ ...prev, title: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="Tidy the playroom"
+              required
+            />
+          </div>
+          <div className="space-y-1 md:col-span-2">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Description</label>
+            <textarea
+              value={choreForm.description}
+              onChange={(event) => setChoreForm((prev) => ({ ...prev, description: event.target.value }))}
+              className="min-h-[140px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="List the steps so everyone knows what finished looks like."
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Picture URL</label>
+            <input
+              value={choreForm.imageUrl}
+              onChange={(event) => setChoreForm((prev) => ({ ...prev, imageUrl: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              placeholder="https://..."
+            />
+            <p className="text-xs text-slate-400 dark:text-slate-500">Add a helpful visual so kids recognize the task.</p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Assign to</label>
+            <select
+              value={choreForm.assignedTo}
+              onChange={(event) => setChoreForm((prev) => ({ ...prev, assignedTo: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            >
+              <option value="">Unassigned</option>
+              {familyMembers.map((member) => (
+                <option key={member.id} value={member.id}>
+                  {member.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Points</label>
+            <input
+              type="number"
+              min="0"
+              value={choreForm.points}
+              onChange={(event) => setChoreForm((prev) => ({ ...prev, points: event.target.value }))}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="w-full rounded-full bg-emerald-500 px-6 py-3 text-lg font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-emerald-600 focus:outline-none focus:ring-4 focus:ring-emerald-300/70"
+            >
+              Add chore
+            </button>
+          </div>
+        </form>
+        <div className="mt-8 grid gap-5 xl:grid-cols-2">
+          {chores.map((chore) => (
+            <ChoreAdminCard key={chore.id} chore={chore} members={familyMembers} onSave={updateChore} onRemove={handleRemoveChore} />
+          ))}
+          {chores.length === 0 && (
+            <p className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
+              No chores yet—add your first task above to populate the board.
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add a global family member switcher with a shared "family" view option
- update the home, chores, and rewards pages to show data for the selected member
- move chore creation into settings and add admin tools for maintaining chores

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f10055e8832699790574608ff9d1