### PR TITLE
Add recurring chore scheduling and rotation

### DIFF
--- a/src/context/FamboardContext.jsx
+++ b/src/context/FamboardContext.jsx
@@ -1,4 +1,8 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import {
+  calculateNextResetTimestamp,
+  getNextRotationAssignee,
+} from '../utils/recurrence.js'
 
 const STORAGE_KEY = 'famboard-state-v1'
 
@@ -35,6 +39,8 @@ const defaultData = {
       completed: false,
       completedAt: null,
       imageUrl: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=200&q=80',
+      recurrence: 'daily',
+      rotateAssignment: false,
     },
     {
       id: 'chore-2',
@@ -45,6 +51,8 @@ const defaultData = {
       completed: false,
       completedAt: null,
       imageUrl: 'https://images.unsplash.com/photo-1543852786-1cf6624b9987?auto=format&fit=crop&w=200&q=80',
+      recurrence: 'weekdays',
+      rotateAssignment: true,
     },
     {
       id: 'chore-3',
@@ -55,6 +63,8 @@ const defaultData = {
       completed: false,
       completedAt: null,
       imageUrl: 'https://images.unsplash.com/photo-1527515637462-cff94eecc1ac?auto=format&fit=crop&w=200&q=80',
+      recurrence: 'weekly',
+      rotateAssignment: false,
     },
   ],
   rewards: [
@@ -90,6 +100,54 @@ export function FamboardProvider({ children }) {
   const [state, setState] = useState(defaultData)
   const [isHydrated, setIsHydrated] = useState(false)
 
+  const runRecurrenceCheck = useCallback(() => {
+    setState((prev) => {
+      if (!prev.chores || prev.chores.length === 0) {
+        return prev
+      }
+
+      const now = Date.now()
+      let updated = false
+
+      const updatedChores = prev.chores.map((chore) => {
+        if (!chore.recurrence || chore.recurrence === 'none') {
+          return chore
+        }
+
+        if (!chore.completed || !chore.completedAt) {
+          return chore
+        }
+
+        const nextReset = calculateNextResetTimestamp(chore.completedAt, chore.recurrence)
+        if (!nextReset || now < nextReset) {
+          return chore
+        }
+
+        const nextAssignee = chore.rotateAssignment
+          ? getNextRotationAssignee(prev.familyMembers, chore.assignedTo)
+          : chore.assignedTo ?? null
+
+        updated = true
+
+        return {
+          ...chore,
+          completed: false,
+          completedAt: null,
+          assignedTo: nextAssignee,
+        }
+      })
+
+      if (!updated) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        chores: updatedChores,
+      }
+    })
+  }, [])
+
   useEffect(() => {
     if (typeof window === 'undefined') return
     try {
@@ -113,6 +171,19 @@ export function FamboardProvider({ children }) {
       console.warn('Unable to persist Famboard data', error)
     }
   }, [state, isHydrated])
+
+  useEffect(() => {
+    if (!isHydrated) return
+    runRecurrenceCheck()
+  }, [isHydrated, state.chores, state.familyMembers, runRecurrenceCheck])
+
+  useEffect(() => {
+    if (!isHydrated || typeof window === 'undefined') return undefined
+    const timer = window.setInterval(runRecurrenceCheck, 60 * 1000)
+    return () => {
+      window.clearInterval(timer)
+    }
+  }, [isHydrated, runRecurrenceCheck])
 
   useEffect(() => {
     if (!isHydrated || typeof document === 'undefined') return
@@ -174,11 +245,15 @@ export function FamboardProvider({ children }) {
               id: createId('chore'),
               title: payload.title,
               description: payload.description,
-              assignedTo: payload.assignedTo ?? null,
+              assignedTo:
+                payload.assignedTo ??
+                (payload.rotateAssignment && prev.familyMembers[0]?.id ? prev.familyMembers[0].id : null),
               points: Math.max(Number(payload.points) || 0, 0),
               completed: false,
               completedAt: null,
               imageUrl: payload.imageUrl ?? '',
+              recurrence: payload.recurrence ?? 'none',
+              rotateAssignment: Boolean(payload.rotateAssignment),
             },
           ],
         })),
@@ -191,8 +266,18 @@ export function FamboardProvider({ children }) {
             updates.points !== undefined
               ? Math.max(Number(updates.points) || 0, 0)
               : existing.points
-          const nextAssigned =
+          let nextAssigned =
             updates.assignedTo !== undefined ? updates.assignedTo : existing.assignedTo
+
+          const nextRecurrence = updates.recurrence ?? existing.recurrence ?? 'none'
+          const nextRotateAssignment =
+            updates.rotateAssignment !== undefined
+              ? Boolean(updates.rotateAssignment)
+              : existing.rotateAssignment ?? false
+
+          if (nextRotateAssignment && !nextAssigned && prev.familyMembers.length > 0) {
+            nextAssigned = prev.familyMembers[0].id
+          }
 
           const updatedChores = prev.chores.map((chore) =>
             chore.id === id
@@ -202,6 +287,8 @@ export function FamboardProvider({ children }) {
                   assignedTo: nextAssigned ?? null,
                   points: nextPoints,
                   imageUrl: updates.imageUrl !== undefined ? updates.imageUrl : chore.imageUrl,
+                  recurrence: nextRecurrence,
+                  rotateAssignment: nextRotateAssignment,
                 }
               : chore,
           )
@@ -374,6 +461,7 @@ export function FamboardProvider({ children }) {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useFamboard() {
   const context = useContext(FamboardContext)
   if (!context) {

--- a/src/utils/recurrence.js
+++ b/src/utils/recurrence.js
@@ -1,0 +1,81 @@
+export const RECURRENCE_OPTIONS = [
+  { value: 'none', label: 'Does not repeat' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'weekdays', label: 'Every weekday (Mon–Fri)' },
+  { value: 'weekends', label: 'Every weekend (Sat & Sun)' },
+  { value: 'monthly', label: 'Monthly' },
+]
+
+export function getRecurrenceLabel(value) {
+  const match = RECURRENCE_OPTIONS.find((option) => option.value === value)
+  return match ? match.label : 'Does not repeat'
+}
+
+export function calculateNextResetTimestamp(completedAt, recurrence) {
+  if (!completedAt || !recurrence || recurrence === 'none') {
+    return null
+  }
+
+  const base = new Date(completedAt)
+  if (Number.isNaN(base.getTime())) {
+    return null
+  }
+
+  switch (recurrence) {
+    case 'daily': {
+      base.setDate(base.getDate() + 1)
+      break
+    }
+    case 'weekly': {
+      base.setDate(base.getDate() + 7)
+      break
+    }
+    case 'monthly': {
+      const date = base.getDate()
+      base.setMonth(base.getMonth() + 1)
+      const lastDayOfMonth = new Date(base.getFullYear(), base.getMonth() + 1, 0).getDate()
+      base.setDate(Math.min(date, lastDayOfMonth))
+      break
+    }
+    case 'weekdays': {
+      do {
+        base.setDate(base.getDate() + 1)
+      } while (isWeekend(base))
+      break
+    }
+    case 'weekends': {
+      do {
+        base.setDate(base.getDate() + 1)
+      } while (!isWeekend(base))
+      break
+    }
+    default:
+      return null
+  }
+
+  return base.getTime()
+}
+
+function isWeekend(date) {
+  const day = date.getDay()
+  return day === 0 || day === 6
+}
+
+export function getNextRotationAssignee(familyMembers, currentAssignedId) {
+  if (!familyMembers || familyMembers.length === 0) {
+    return null
+  }
+
+  if (!currentAssignedId) {
+    return familyMembers[0].id
+  }
+
+  const currentIndex = familyMembers.findIndex((member) => member.id === currentAssignedId)
+  if (currentIndex === -1) {
+    return familyMembers[0].id
+  }
+
+  const nextIndex = (currentIndex + 1) % familyMembers.length
+  return familyMembers[nextIndex].id
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,4 @@
+/* global process */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 


### PR DESCRIPTION
## Summary
- add recurrence utilities and scheduling helpers for chore data
- expose recurrence and rotation controls in chore management and dashboard views
- automatically reset completed recurring chores and rotate assignments between family members

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5f6616d2883268355f08fbbeac942