### PR TITLE
Add chore calendar views

### DIFF
--- a/src/components/ChoreCalendar.jsx
+++ b/src/components/ChoreCalendar.jsx
@@ -1,0 +1,496 @@
+import { Fragment, useMemo, useState } from 'react'
+import { getRecurrenceLabel } from '../utils/recurrence.js'
+import {
+  addDays,
+  addMonthsPreservingDay,
+  endOfMonth,
+  endOfWeek,
+  formatDateLabel,
+  getDateKey,
+  isSameDay,
+  isWeekend,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  toStartOfDayISOString,
+  DAY_MS,
+} from '../utils/date.js'
+
+const VIEWS = [
+  { id: 'day', label: 'Day view' },
+  { id: 'week', label: 'Week view' },
+  { id: 'month', label: 'Month view' },
+]
+
+export function ChoreCalendar({ chores, familyMembers, focusMember }) {
+  const [activeView, setActiveView] = useState('week')
+  const [focusDate, setFocusDate] = useState(() => startOfDay(new Date()))
+
+  const memberMap = useMemo(() => {
+    const map = new Map()
+    familyMembers.forEach((member) => {
+      map.set(member.id, member)
+    })
+    return map
+  }, [familyMembers])
+
+  const range = useMemo(() => computeRange(activeView, focusDate), [activeView, focusDate])
+  const daysInRange = useMemo(() => createDateRange(range.start, range.end), [range.start, range.end])
+  const occurrenceMap = useMemo(
+    () => buildOccurrenceMap(chores, range.start, range.end),
+    [chores, range.start, range.end],
+  )
+
+  const focusKey = getDateKey(focusDate)
+  const todayKey = getDateKey(new Date())
+
+  const focusLabel = useMemo(
+    () => formatRangeLabel(activeView, focusDate, range),
+    [activeView, focusDate, range],
+  )
+
+  const goToPrevious = () => {
+    setFocusDate((current) => {
+      if (activeView === 'day') return startOfDay(addDays(current, -1))
+      if (activeView === 'week') return startOfDay(addDays(current, -7))
+      return addMonthsPreservingDay(current, -1, current.getDate())
+    })
+  }
+
+  const goToNext = () => {
+    setFocusDate((current) => {
+      if (activeView === 'day') return startOfDay(addDays(current, 1))
+      if (activeView === 'week') return startOfDay(addDays(current, 7))
+      return addMonthsPreservingDay(current, 1, current.getDate())
+    })
+  }
+
+  const goToToday = () => {
+    setFocusDate(startOfDay(new Date()))
+  }
+
+  const subjectLabel = focusMember
+    ? `${focusMember.name}’s schedule`
+    : 'Family schedule'
+
+  const dayOccurrences = occurrenceMap.get(focusKey) ?? []
+
+  const weeksForMonth = useMemo(() => {
+    if (activeView !== 'month') return []
+    const chunked = []
+    for (let index = 0; index < daysInRange.length; index += 7) {
+      chunked.push(daysInRange.slice(index, index + 7))
+    }
+    return chunked
+  }, [activeView, daysInRange])
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-1">
+            <h2 className="font-display text-2xl text-slate-800 dark:text-white">Chore calendar</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {subjectLabel} · Normalized for future Google, Apple, or Outlook calendar syncs.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={goToPrevious}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-300 text-lg text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-famboard-primary focus:ring-offset-2 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              aria-label="Previous period"
+            >
+              ‹
+            </button>
+            <span className="rounded-full bg-famboard-primary/10 px-4 py-2 text-sm font-semibold text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+              {focusLabel}
+            </span>
+            <button
+              type="button"
+              onClick={goToNext}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-300 text-lg text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-famboard-primary focus:ring-offset-2 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              aria-label="Next period"
+            >
+              ›
+            </button>
+            <button
+              type="button"
+              onClick={goToToday}
+              className="inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-famboard-primary focus:ring-offset-2 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              Today
+            </button>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {VIEWS.map((view) => (
+            <button
+              key={view.id}
+              type="button"
+              onClick={() => setActiveView(view.id)}
+              className={`rounded-full px-4 py-2 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+                activeView === view.id
+                  ? 'bg-famboard-primary text-white shadow-lg focus:ring-famboard-accent'
+                  : 'bg-white text-slate-600 shadow focus:ring-famboard-primary/40 hover:bg-famboard-primary/10 hover:text-famboard-primary dark:bg-slate-800 dark:text-slate-300'
+              }`}
+              aria-pressed={activeView === view.id}
+            >
+              {view.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {activeView === 'day' && (
+        <div className="space-y-4">
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Everything planned for {formatDateLabel(focusDate, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}.
+          </p>
+          {dayOccurrences.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-slate-300/70 bg-white/70 p-6 text-sm text-slate-500 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
+              No chores scheduled for this day. Update an anchor date or recurrence to add something special.
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {dayOccurrences.map((occurrence) => (
+                <li key={occurrence.id}>
+                  <CalendarDayCard
+                    occurrence={occurrence}
+                    member={memberMap.get(occurrence.assignedTo) ?? null}
+                    todayKey={todayKey}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {activeView === 'week' && (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-7">
+          {daysInRange.map((date) => {
+            const key = getDateKey(date)
+            const occurrences = occurrenceMap.get(key) ?? []
+            const isToday = key === todayKey
+            const isFocused = key === focusKey
+            return (
+              <article
+                key={key}
+                className={`flex min-h-[10rem] flex-col rounded-2xl border p-4 shadow-sm transition ${
+                  isFocused
+                    ? 'border-famboard-primary bg-famboard-primary/5 dark:border-sky-500 dark:bg-sky-500/10'
+                    : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900'
+                }`}
+              >
+                <header className="mb-3 flex items-baseline justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                      {formatDateLabel(date, { weekday: 'short' })}
+                    </p>
+                    <p className={`text-lg font-display ${
+                      isToday ? 'text-famboard-primary dark:text-sky-300' : 'text-slate-700 dark:text-slate-200'
+                    }`}>
+                      {formatDateLabel(date, { month: 'short', day: 'numeric' })}
+                    </p>
+                  </div>
+                  {isToday && (
+                    <span className="rounded-full bg-famboard-primary/10 px-3 py-1 text-xs font-semibold text-famboard-primary dark:bg-sky-500/20 dark:text-sky-100">
+                      Today
+                    </span>
+                  )}
+                </header>
+                <div className="flex flex-1 flex-col gap-2">
+                  {occurrences.length === 0 ? (
+                    <p className="text-xs text-slate-400 dark:text-slate-500">No chores planned.</p>
+                  ) : (
+                    occurrences.map((occurrence) => (
+                      <EventChip
+                        key={occurrence.id}
+                        occurrence={occurrence}
+                        member={memberMap.get(occurrence.assignedTo) ?? null}
+                      />
+                    ))
+                  )}
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+
+      {activeView === 'month' && (
+        <div className="space-y-2">
+          <div className="grid grid-cols-7 gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+            {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((label) => (
+              <span key={label} className="text-center">
+                {label}
+              </span>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-px rounded-3xl bg-slate-200/80 p-px dark:bg-slate-800/80">
+            {weeksForMonth.map((week, index) => (
+              <Fragment key={index}>
+                {week.map((date) => {
+                  const key = getDateKey(date)
+                  const occurrences = occurrenceMap.get(key) ?? []
+                  const isToday = key === todayKey
+                  const isFocused = key === focusKey
+                  const isCurrentMonth = date.getMonth() === range.anchorMonth
+                  return (
+                    <div
+                      key={key}
+                      className={`flex min-h-[7rem] flex-col gap-1 rounded-2xl border bg-white p-2 text-left shadow-sm dark:bg-slate-900 ${
+                        isFocused
+                          ? 'border-famboard-primary/60 ring-1 ring-famboard-primary/40 dark:border-sky-500/60 dark:ring-sky-500/40'
+                          : 'border-transparent'
+                      } ${
+                        !isCurrentMonth ? 'opacity-50' : ''
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className={`text-sm font-semibold ${
+                          isToday ? 'text-famboard-primary dark:text-sky-300' : 'text-slate-600 dark:text-slate-300'
+                        }`}>
+                          {date.getDate()}
+                        </span>
+                        {isToday && (
+                          <span className="rounded-full bg-famboard-primary/10 px-2 py-0.5 text-[0.6rem] font-semibold text-famboard-primary dark:bg-sky-500/20 dark:text-sky-100">
+                            Today
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex flex-1 flex-col gap-1">
+                        {occurrences.slice(0, 3).map((occurrence) => (
+                          <EventChip
+                            key={occurrence.id}
+                            occurrence={occurrence}
+                            member={memberMap.get(occurrence.assignedTo) ?? null}
+                            compact
+                          />
+                        ))}
+                        {occurrences.length > 3 && (
+                          <p className="text-[0.65rem] text-slate-400 dark:text-slate-500">
+                            +{occurrences.length - 3} more chore{occurrences.length - 3 === 1 ? '' : 's'}
+                          </p>
+                        )}
+                        {occurrences.length === 0 && (
+                          <p className="text-[0.65rem] text-slate-400 dark:text-slate-500">No chores</p>
+                        )}
+                      </div>
+                    </div>
+                  )
+                })}
+              </Fragment>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CalendarDayCard({ occurrence, member, todayKey }) {
+  const isToday = occurrence.dateKey === todayKey
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm transition hover:border-famboard-primary/60 dark:border-slate-700 dark:bg-slate-900">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-semibold text-slate-700 dark:text-slate-100">{occurrence.title}</p>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            {member ? `Assigned to ${member.name}` : 'Unassigned'} · {getRecurrenceLabel(occurrence.recurrence)}
+          </p>
+        </div>
+        <span
+          className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+            occurrence.isCompletedToday && isToday
+              ? 'bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200'
+              : 'bg-famboard-primary/10 text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200'
+          }`}
+        >
+          {occurrence.isCompletedToday && isToday ? 'Completed' : `${occurrence.points} pts`}
+        </span>
+      </div>
+      {occurrence.description && (
+        <p className="text-sm text-slate-500 dark:text-slate-400">{occurrence.description}</p>
+      )}
+      <p className="text-[0.65rem] text-slate-400 dark:text-slate-500">
+        Event UID: {occurrence.icsEvent.uid}
+      </p>
+    </div>
+  )
+}
+
+function EventChip({ occurrence, member, compact = false }) {
+  const textClass = compact ? 'text-[0.65rem]' : 'text-xs'
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-full bg-famboard-primary/10 px-3 py-1 font-medium text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200 ${textClass}`}
+      data-rrule={occurrence.icsEvent.recurrenceRule ?? undefined}
+    >
+      <span className="truncate">{occurrence.title}</span>
+      {member && <span className="hidden truncate text-[0.6rem] text-slate-500 dark:text-slate-300 sm:inline">{member.name}</span>}
+    </div>
+  )
+}
+
+function computeRange(view, focusDate) {
+  const anchor = startOfDay(focusDate)
+  if (view === 'day') {
+    return {
+      start: anchor,
+      end: anchor,
+      anchorMonth: anchor.getMonth(),
+    }
+  }
+  if (view === 'week') {
+    const start = startOfWeek(anchor)
+    return {
+      start,
+      end: endOfWeek(anchor),
+      anchorMonth: anchor.getMonth(),
+    }
+  }
+  const monthStart = startOfMonth(anchor)
+  const monthEnd = endOfMonth(anchor)
+  return {
+    start: startOfWeek(monthStart),
+    end: endOfWeek(monthEnd),
+    anchorMonth: anchor.getMonth(),
+  }
+}
+
+function createDateRange(start, end) {
+  const dates = []
+  const first = startOfDay(start).getTime()
+  const last = startOfDay(end).getTime()
+  for (let time = first; time <= last; time += DAY_MS) {
+    dates.push(new Date(time))
+  }
+  return dates
+}
+
+function formatRangeLabel(view, focusDate, range) {
+  if (view === 'day') {
+    return formatDateLabel(focusDate, {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
+  if (view === 'week') {
+    const sameYear = range.start.getFullYear() === range.end.getFullYear()
+    const startLabel = formatDateLabel(range.start, { month: 'short', day: 'numeric' })
+    const endLabel = formatDateLabel(range.end, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+    return sameYear ? `${startLabel} – ${endLabel}` : `${startLabel} – ${endLabel}`
+  }
+  return formatDateLabel(focusDate, { month: 'long', year: 'numeric' })
+}
+
+function buildOccurrenceMap(chores, rangeStart, rangeEnd) {
+  const map = new Map()
+  const start = startOfDay(rangeStart).getTime()
+  const end = startOfDay(rangeEnd).getTime()
+  for (let time = start; time <= end; time += DAY_MS) {
+    const key = getDateKey(new Date(time))
+    map.set(key, [])
+  }
+
+  chores.forEach((chore) => {
+    const anchor = startOfDay(chore?.schedule?.anchorDate ?? new Date())
+    const recurrence = chore?.recurrence ?? 'none'
+    for (let time = start; time <= end; time += DAY_MS) {
+      const date = new Date(time)
+      if (!occursOnDate(anchor, recurrence, date)) continue
+      const key = getDateKey(date)
+      const existing = map.get(key)
+      if (!existing) continue
+      existing.push(createOccurrence(chore, date))
+    }
+  })
+
+  Array.from(map.entries()).forEach(([key, events]) => {
+    events.sort((a, b) => a.title.localeCompare(b.title))
+    map.set(key, events)
+  })
+
+  return map
+}
+
+function occursOnDate(anchor, recurrence, date) {
+  const target = startOfDay(date)
+  const diffDays = Math.floor((target.getTime() - anchor.getTime()) / DAY_MS)
+  if (recurrence === 'none') {
+    return diffDays === 0
+  }
+  if (diffDays < 0) {
+    return false
+  }
+  switch (recurrence) {
+    case 'daily':
+      return diffDays >= 0
+    case 'weekly':
+      return diffDays % 7 === 0
+    case 'weekdays':
+      return !isWeekend(target)
+    case 'weekends':
+      return isWeekend(target)
+    case 'monthly': {
+      const monthsApart =
+        (target.getFullYear() - anchor.getFullYear()) * 12 +
+        (target.getMonth() - anchor.getMonth())
+      if (monthsApart < 0) return false
+      const candidate = addMonthsPreservingDay(anchor, monthsApart, anchor.getDate())
+      return isSameDay(candidate, target)
+    }
+    default:
+      return false
+  }
+}
+
+function createOccurrence(chore, date) {
+  const dateKey = getDateKey(date)
+  const isToday = isSameDay(date, new Date())
+  return {
+    id: `${chore.id}-${dateKey}`,
+    choreId: chore.id,
+    title: chore.title,
+    description: chore.description ?? '',
+    date,
+    dateKey,
+    assignedTo: chore.assignedTo ?? null,
+    points: chore.points ?? 0,
+    recurrence: chore.recurrence ?? 'none',
+    isCompletedToday: Boolean(chore.completed && isToday),
+    icsEvent: {
+      uid: `${chore.id}-${dateKey}@famboard.local`,
+      summary: chore.title,
+      start: toStartOfDayISOString(date),
+      allDay: true,
+      recurrenceRule: mapRecurrenceToRRule(chore.recurrence),
+      description: chore.description ?? '',
+    },
+  }
+}
+
+function mapRecurrenceToRRule(recurrence) {
+  switch (recurrence) {
+    case 'daily':
+      return 'FREQ=DAILY'
+    case 'weekly':
+      return 'FREQ=WEEKLY'
+    case 'weekdays':
+      return 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR'
+    case 'weekends':
+      return 'FREQ=WEEKLY;BYDAY=SA,SU'
+    case 'monthly':
+      return 'FREQ=MONTHLY'
+    default:
+      return null
+  }
+}

--- a/src/pages/SettingsScreen.jsx
+++ b/src/pages/SettingsScreen.jsx
@@ -6,6 +6,12 @@ import { useFamboard } from '../context/FamboardContext.jsx'
 import { getRecurrenceLabel, RECURRENCE_OPTIONS } from '../utils/recurrence.js'
 import { MediaPicker } from '../components/MediaPicker.jsx'
 import { MediaImage } from '../components/MediaImage.jsx'
+import {
+  formatDateForInput,
+  formatDateLabel,
+  parseInputDateToISO,
+  toStartOfDayISOString,
+} from '../utils/date.js'
 
 const APP_VERSION = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev'
 
@@ -185,6 +191,7 @@ function ChoreAdminCard({ chore, members, onSave, onRemove }) {
     imageUrl: chore.imageUrl ?? '',
     recurrence: chore.recurrence ?? 'none',
     rotateAssignment: Boolean(chore.rotateAssignment),
+    scheduleAnchor: formatDateForInput(chore.schedule?.anchorDate ?? toStartOfDayISOString(new Date())),
   })
 
   useEffect(() => {
@@ -197,6 +204,7 @@ function ChoreAdminCard({ chore, members, onSave, onRemove }) {
       imageUrl: chore.imageUrl ?? '',
       recurrence: chore.recurrence ?? 'none',
       rotateAssignment: Boolean(chore.rotateAssignment),
+      scheduleAnchor: formatDateForInput(chore.schedule?.anchorDate ?? toStartOfDayISOString(new Date())),
     })
   }, [chore])
 
@@ -213,6 +221,10 @@ function ChoreAdminCard({ chore, members, onSave, onRemove }) {
       imageUrl: form.imageUrl.trim(),
       recurrence: form.recurrence,
       rotateAssignment: form.rotateAssignment,
+      schedule: {
+        anchorDate: parseInputDateToISO(form.scheduleAnchor, chore.schedule?.anchorDate),
+        allDay: true,
+      },
     })
     setIsEditing(false)
   }
@@ -320,6 +332,23 @@ function ChoreAdminCard({ chore, members, onSave, onRemove }) {
                 <p className="text-xs text-rose-500">Add family members to enable rotation.</p>
               )}
             </div>
+            <div className="space-y-1 sm:col-span-2">
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Starts on</label>
+              <input
+                type="date"
+                value={form.scheduleAnchor}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    scheduleAnchor: event.target.value,
+                  }))
+                }
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+              />
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                Align this anchor date with your household calendar so sync exports stay accurate.
+              </p>
+            </div>
           </div>
           <div className="flex flex-wrap gap-3">
             <button
@@ -377,6 +406,9 @@ function ChoreAdminCard({ chore, members, onSave, onRemove }) {
                   </span>
                 )}
               </div>
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                Starts {formatDateLabel(chore.schedule?.anchorDate, { month: 'short', day: 'numeric', year: 'numeric' }) || 'soon'}
+              </p>
             </div>
           </div>
           <div className="flex flex-wrap gap-3">
@@ -435,6 +467,7 @@ export default function SettingsScreen() {
     imageUrl: '',
     recurrence: 'none',
     rotateAssignment: false,
+    scheduleAnchor: formatDateForInput(toStartOfDayISOString(new Date())),
   })
 
   const totalPoints = useMemo(
@@ -517,6 +550,10 @@ export default function SettingsScreen() {
       imageUrl: choreForm.imageUrl.trim(),
       recurrence: choreForm.recurrence,
       rotateAssignment: choreForm.rotateAssignment,
+      schedule: {
+        anchorDate: parseInputDateToISO(choreForm.scheduleAnchor),
+        allDay: true,
+      },
     })
     setChoreForm({
       title: '',
@@ -527,6 +564,7 @@ export default function SettingsScreen() {
       imageUrl: '',
       recurrence: 'none',
       rotateAssignment: false,
+      scheduleAnchor: formatDateForInput(toStartOfDayISOString(new Date())),
     })
   }
 
@@ -796,6 +834,23 @@ export default function SettingsScreen() {
                   {choreForm.rotateAssignment && familyMembers.length === 0 && (
                     <p className="text-xs text-rose-500">Add family members to enable rotation.</p>
                   )}
+                </div>
+                <div className="space-y-2 md:col-span-2">
+                  <label className="text-sm font-semibold text-slate-600 dark:text-slate-200">Starts on</label>
+                  <input
+                    type="date"
+                    value={choreForm.scheduleAnchor}
+                    onChange={(event) =>
+                      setChoreForm((prev) => ({
+                        ...prev,
+                        scheduleAnchor: event.target.value,
+                      }))
+                    }
+                    className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
+                  />
+                  <p className="text-xs text-slate-400 dark:text-slate-500">
+                    We’ll use this anchor date to power the new calendar views and upcoming sync exports.
+                  </p>
                 </div>
               </div>
               <div className="flex justify-end">

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,112 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000
+
+export function startOfDay(value = new Date()) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return startOfDay(new Date())
+  }
+  date.setHours(0, 0, 0, 0)
+  return date
+}
+
+export function endOfDay(value = new Date()) {
+  const date = startOfDay(value)
+  date.setHours(23, 59, 59, 999)
+  return date
+}
+
+export function addDays(value, amount) {
+  const date = new Date(value)
+  date.setDate(date.getDate() + amount)
+  return date
+}
+
+export function startOfWeek(value = new Date()) {
+  const date = startOfDay(value)
+  const day = date.getDay()
+  return addDays(date, -day)
+}
+
+export function endOfWeek(value = new Date()) {
+  const date = startOfWeek(value)
+  return addDays(date, 6)
+}
+
+export function startOfMonth(value = new Date()) {
+  const date = startOfDay(value)
+  date.setDate(1)
+  return date
+}
+
+export function endOfMonth(value = new Date()) {
+  const date = startOfMonth(value)
+  date.setMonth(date.getMonth() + 1)
+  date.setDate(0)
+  return endOfDay(date)
+}
+
+export function toStartOfDayISOString(value = new Date()) {
+  return startOfDay(value).toISOString()
+}
+
+export function formatDateForInput(value) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function parseInputDateToISO(value, fallback) {
+  if (!value) {
+    return fallback ? toStartOfDayISOString(fallback) : toStartOfDayISOString(new Date())
+  }
+  const [year, month, day] = value.split('-').map(Number)
+  if (!year || !month || !day) {
+    return fallback ? toStartOfDayISOString(fallback) : toStartOfDayISOString(new Date())
+  }
+  const date = new Date(year, month - 1, day)
+  if (Number.isNaN(date.getTime())) {
+    return fallback ? toStartOfDayISOString(fallback) : toStartOfDayISOString(new Date())
+  }
+  return toStartOfDayISOString(date)
+}
+
+export function formatDateLabel(value, options) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return new Intl.DateTimeFormat(undefined, options).format(date)
+}
+
+export function getDateKey(value) {
+  return formatDateForInput(startOfDay(value).toISOString())
+}
+
+export function isWeekend(value) {
+  const date = new Date(value)
+  const day = date.getDay()
+  return day === 0 || day === 6
+}
+
+export function addMonthsPreservingDay(value, amount, anchorDay) {
+  const date = startOfDay(value)
+  const targetDay = anchorDay ?? date.getDate()
+  date.setMonth(date.getMonth() + amount)
+  const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
+  date.setDate(Math.min(targetDay, lastDay))
+  return date
+}
+
+export function isSameDay(a, b) {
+  if (!a || !b) return false
+  const first = startOfDay(a)
+  const second = startOfDay(b)
+  return first.getTime() === second.getTime()
+}
+
+export const DAY_MS = DAY_IN_MS


### PR DESCRIPTION
## Summary
- add a chore calendar component that renders day, week, and month views with ICS-friendly metadata
- extend chores to include a schedule anchor date and surface scheduling controls in the Chores and Settings screens
- add date utility helpers used to generate calendar ranges and normalize scheduled occurrences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e69b7063588326bc0b9ab8a37663f3