### PR TITLE
Enhance reward shelf storefront presentation

### DIFF
--- a/src/pages/RewardsScreen.jsx
+++ b/src/pages/RewardsScreen.jsx
@@ -69,8 +69,8 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave, canManage = t
   }
 
   return (
-    <div className="group relative overflow-hidden rounded-3xl border border-transparent bg-white/90 p-6 shadow-card transition hover:border-famboard-primary/40 hover:shadow-xl dark:bg-slate-900/80">
-      <div className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full bg-famboard-primary/10 blur-2xl transition group-hover:bg-famboard-primary/20" aria-hidden />
+    <div className="group relative flex flex-col overflow-hidden rounded-[2rem] border border-transparent bg-white/95 shadow-card transition hover:-translate-y-1 hover:border-famboard-primary/50 hover:shadow-2xl dark:bg-slate-900/90">
+      <div className="pointer-events-none absolute -right-16 -top-24 h-48 w-48 rounded-full bg-famboard-primary/10 blur-3xl transition group-hover:bg-famboard-primary/20" aria-hidden />
       {isEditing && canManage ? (
         <form className="space-y-4" onSubmit={handleSubmit}>
           <MediaPicker
@@ -137,61 +137,73 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave, canManage = t
           </div>
         </form>
       ) : (
-        <div className="space-y-4">
-          <div className="flex items-start gap-4">
-            <div className="h-20 w-20 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner dark:border-slate-700 dark:bg-slate-800">
-              {reward.imageId ? (
-                <MediaImage
-                  mediaId={reward.imageId}
-                  alt={reward.title}
-                  className="h-full w-full object-cover"
-                  fallback={<div className="flex h-full w-full items-center justify-center text-3xl">🎁</div>}
-                />
-              ) : reward.imageUrl ? (
-                <img src={reward.imageUrl} alt={reward.title} className="h-full w-full object-cover" />
+        <>
+          <div className="relative aspect-[4/3] w-full overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-br from-slate-900/10 via-transparent to-slate-900/20 opacity-30 transition-opacity group-hover:opacity-50" aria-hidden />
+            {reward.imageId ? (
+              <MediaImage
+                mediaId={reward.imageId}
+                alt={reward.title}
+                className="h-full w-full object-cover"
+                fallback={<div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-famboard-primary/30 to-emerald-400/30 text-5xl">🎁</div>}
+              />
+            ) : reward.imageUrl ? (
+              <img src={reward.imageUrl} alt={reward.title} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-famboard-primary/30 to-emerald-400/30 text-5xl">🎁</div>
+            )}
+            <div className="absolute inset-x-0 bottom-0 flex justify-between p-4 text-white">
+              <div className="max-w-[70%]">
+                <p className="text-xs font-medium uppercase tracking-[0.2em] text-white/80">Reward spotlight</p>
+                <p className="mt-1 text-lg font-semibold leading-tight drop-shadow">{reward.title}</p>
+              </div>
+              <span className="inline-flex items-center rounded-full bg-white/95 px-3 py-1 text-sm font-semibold text-famboard-dark shadow-lg">
+                {reward.cost} pts
+              </span>
+            </div>
+          </div>
+          <div className="space-y-5 p-6">
+            <div className="space-y-2">
+              <h3 className="text-2xl font-semibold text-slate-900 transition group-hover:text-famboard-primary dark:text-white">
+                {reward.title}
+              </h3>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                {reward.description || 'Add a fun description to get everyone excited!'}
+              </p>
+            </div>
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Claim for
+              </p>
+              {members.length === 0 ? (
+                <div className="rounded-full border border-dashed border-slate-300/80 bg-white/70 px-4 py-2 text-sm text-slate-500 shadow-inner dark:border-slate-700/80 dark:bg-slate-900/70 dark:text-slate-400">
+                  Add family members first
+                </div>
               ) : (
-                <div className="flex h-full w-full items-center justify-center text-3xl">🎁</div>
+                <div className="flex flex-wrap gap-2">
+                  {members.map((member) => {
+                    const isSelected = member.id === selectedMember
+                    return (
+                      <button
+                        key={member.id}
+                        type="button"
+                        onClick={() => setSelectedMember(member.id)}
+                        className={`rounded-full border px-3 py-1.5 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
+                          isSelected
+                            ? 'border-transparent bg-famboard-primary text-white shadow-lg'
+                            : 'border-slate-200 bg-white/80 text-slate-600 hover:border-famboard-primary/60 hover:text-famboard-primary dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-300'
+                        }`}
+                      >
+                        <span>{member.name}</span>
+                        <span className={`ml-2 text-xs font-medium ${isSelected ? 'text-white/80' : 'text-slate-500 dark:text-slate-400'}`}>
+                          {member.points} pts
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
               )}
             </div>
-            <div className="flex-1 space-y-2">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <h3 className="text-xl font-semibold text-slate-900 transition group-hover:text-famboard-primary dark:text-white">
-                    {reward.title}
-                  </h3>
-                  <p className="text-sm text-slate-500 dark:text-slate-400">
-                    {reward.description || 'Add a fun description to get everyone excited!'}
-                  </p>
-                </div>
-                <span className="rounded-full bg-gradient-to-r from-famboard-primary/10 via-famboard-accent/20 to-emerald-400/20 px-3 py-1 text-sm font-semibold text-famboard-dark dark:from-sky-500/10 dark:via-emerald-400/20 dark:to-amber-300/20 dark:text-amber-200">
-                  {reward.cost} pts
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="space-y-3">
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              Redeem for
-            </label>
-            {members.length <= 1 ? (
-              <div className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm shadow-inner dark:border-slate-700 dark:bg-slate-900">
-                {members.length === 0 ? 'Add family members first' : `${members[0].name} · ${members[0].points} pts`}
-              </div>
-            ) : (
-              <select
-                value={selectedMember}
-                onChange={(event) => setSelectedMember(event.target.value)}
-                className="w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-base shadow-inner focus:border-famboard-primary focus:outline-none focus:ring-2 focus:ring-famboard-primary/30 dark:border-slate-700 dark:bg-slate-900"
-              >
-                {members.length === 0 && <option value="">Add family members first</option>}
-                {members.map((member) => (
-                  <option key={member.id} value={member.id}>
-                    {member.name} · {member.points} pts
-                  </option>
-                ))}
-              </select>
-            )}
-          </div>
           {selectedMemberData && (
             <div className="space-y-1">
               <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -208,42 +220,43 @@ function RewardCard({ reward, members, onRedeem, onDelete, onSave, canManage = t
               </div>
             </div>
           )}
-          <div className="flex flex-wrap items-center gap-3">
-            <button
-              onClick={() => selectedMember && onRedeem(selectedMember, reward.id)}
-              disabled={!canRedeem}
-              className={`flex-1 rounded-full px-4 py-2 text-sm font-semibold text-white shadow focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 ${
-                canRedeem
-                  ? 'bg-emerald-500 hover:bg-emerald-600 focus:ring-emerald-400'
-                  : 'bg-slate-400 focus:ring-slate-300'
-              }`}
-            >
-              Redeem reward
-            </button>
-            {canManage && (
-              <>
-                <button
-                  onClick={() => setIsEditing(true)}
-                  className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => onDelete(reward.id)}
-                  className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
-                >
-                  Delete
-                </button>
-              </>
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                onClick={() => selectedMember && onRedeem(selectedMember, reward.id)}
+                disabled={!canRedeem}
+                className={`flex-1 rounded-full px-4 py-2 text-sm font-semibold text-white shadow focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 ${
+                  canRedeem
+                    ? 'bg-emerald-500 hover:bg-emerald-600 focus:ring-emerald-400'
+                    : 'bg-slate-400 focus:ring-slate-300'
+                }`}
+              >
+                Redeem reward
+              </button>
+              {canManage && (
+                <>
+                  <button
+                    onClick={() => setIsEditing(true)}
+                    className="rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => onDelete(reward.id)}
+                    className="rounded-full border border-rose-400 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-300 focus:ring-offset-2 dark:border-rose-500 dark:text-rose-300 dark:hover:bg-rose-500/10"
+                  >
+                    Delete
+                  </button>
+                </>
+              )}
+            </div>
+            {!canRedeem && selectedMember && (
+              <p className="text-xs font-medium text-rose-500 dark:text-rose-300">
+                {members.find((member) => member.id === selectedMember)?.name ?? 'They'}
+                {' needs more points to redeem this reward.'}
+              </p>
             )}
           </div>
-          {!canRedeem && selectedMember && (
-            <p className="text-xs font-medium text-rose-500 dark:text-rose-300">
-              {members.find((member) => member.id === selectedMember)?.name ?? 'They'}
-              {' needs more points to redeem this reward.'}
-            </p>
-          )}
-        </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- restyle reward cards with storefront-inspired layout and large imagery
- replace member selection dropdown with quick-select chips to highlight each claimant

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6a78d0e448326a08a1b931c27a430