### PR TITLE
Add inspiration gallery for chore and reward creation

### DIFF
--- a/src/components/IdeaGallery.jsx
+++ b/src/components/IdeaGallery.jsx
@@ -1,0 +1,73 @@
+import { MediaImage } from './MediaImage.jsx'
+
+export function IdeaGallery({ title, description, items, actionLabel = 'Use this idea', onSelect }) {
+  if (!items || items.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-10 space-y-6">
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h3>
+        {description && <p className="text-sm text-slate-500 dark:text-slate-400">{description}</p>}
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {items.map((item) => (
+          <article
+            key={item.id}
+            className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/70 bg-white/80 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-slate-700/70 dark:bg-slate-900/70"
+          >
+            {item.imageId || item.imageUrl ? (
+              <div className="relative h-40 w-full overflow-hidden bg-slate-100 dark:bg-slate-800">
+                {item.imageId ? (
+                  <MediaImage
+                    mediaId={item.imageId}
+                    alt={item.title}
+                    className="h-full w-full object-cover"
+                    fallback={<div className="flex h-full w-full items-center justify-center text-4xl">{item.emoji ?? '✨'}</div>}
+                  />
+                ) : (
+                  <img src={item.imageUrl} alt={item.imageAlt ?? item.title} className="h-full w-full object-cover" />
+                )}
+              </div>
+            ) : item.emoji ? (
+              <div className="flex h-40 w-full items-center justify-center bg-gradient-to-br from-famboard-primary/10 via-sky-400/10 to-violet-400/10 text-5xl">
+                {item.emoji}
+              </div>
+            ) : null}
+            <div className="flex flex-1 flex-col justify-between gap-4 p-5">
+              <div className="space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <h4 className="text-base font-semibold text-slate-800 dark:text-slate-100">{item.title}</h4>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">{item.description}</p>
+                  </div>
+                  {item.badge && (
+                    <span className="shrink-0 rounded-full bg-famboard-primary/10 px-3 py-1 text-xs font-semibold text-famboard-primary dark:bg-sky-500/10 dark:text-sky-200">
+                      {item.badge}
+                    </span>
+                  )}
+                </div>
+                {item.meta && (
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">{item.meta}</p>
+                )}
+                {item.tips && (
+                  <p className="text-xs text-slate-400 dark:text-slate-500">{item.tips}</p>
+                )}
+              </div>
+              <div className="flex">
+                <button
+                  type="button"
+                  onClick={() => onSelect?.(item)}
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-famboard-primary px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-famboard-dark focus:outline-none focus:ring-2 focus:ring-famboard-accent focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+                >
+                  {actionLabel}
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/data/ideaDecks.js
+++ b/src/data/ideaDecks.js
@@ -1,0 +1,131 @@
+export const CHORE_IDEAS = [
+  {
+    id: 'chore-tidy-playroom',
+    title: 'Playroom power tidy',
+    description: 'Set a 10-minute timer, scoop toys into their homes, and reset the cozy corners for tomorrow\'s adventures.',
+    points: 10,
+    recurrence: 'daily',
+    rotateAssignment: true,
+    imageUrl: 'https://images.unsplash.com/photo-1528747008803-1ef8ab69c64b?auto=format&fit=crop&w=800&q=80',
+    emoji: '🧸',
+    tips: 'Great as a shared sprint—whoever fills their basket first picks the bedtime story.'
+  },
+  {
+    id: 'chore-backpack-launchpad',
+    title: 'Backpack launchpad check',
+    description: 'Refill water bottles, tuck homework inside, and hang backpacks by the door for an easy morning exit.',
+    points: 8,
+    recurrence: 'weekdays',
+    rotateAssignment: false,
+    imageUrl: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&w=800&q=80',
+    emoji: '🎒',
+    tips: 'Pair it with a quick weather check so outfits are ready too.'
+  },
+  {
+    id: 'chore-plant-care',
+    title: 'Plant care patrol',
+    description: 'Check leaves, water thirsty plants, and give the green crew a gentle turn toward the sun.',
+    points: 9,
+    recurrence: 'weekly',
+    rotateAssignment: true,
+    imageUrl: 'https://images.unsplash.com/photo-1524593147083-2d60b25b1034?auto=format&fit=crop&w=800&q=80',
+    emoji: '🪴',
+    tips: 'Let kids name the plants they tend—they love checking on their leafy friends.'
+  },
+  {
+    id: 'chore-laundry-launch',
+    title: 'Laundry launch assistant',
+    description: 'Sort colors from lights, load the washer, and start the cycle with a fresh dryer sheet ready to go.',
+    points: 12,
+    recurrence: 'weekly',
+    rotateAssignment: false,
+    imageUrl: 'https://images.unsplash.com/photo-1581578731548-c64695cc6952?auto=format&fit=crop&w=800&q=80',
+    emoji: '🧺',
+    tips: 'Hand younger helpers a sock-matching challenge while the machine runs.'
+  },
+  {
+    id: 'chore-fridge-refresh',
+    title: 'Snack station refresh',
+    description: 'Wipe fridge shelves, compost old leftovers, and restock easy-grab snacks in labeled bins.',
+    points: 14,
+    recurrence: 'weekly',
+    rotateAssignment: false,
+    imageUrl: 'https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=800&q=80',
+    emoji: '🥕',
+    tips: 'Invite the helper to pick one new snack to add to the bin this week.'
+  },
+  {
+    id: 'chore-trash-team',
+    title: 'Trash & recycle team-up',
+    description: 'Gather bins around the house, sort recyclables, and roll everything to the curb before pickup day.',
+    points: 11,
+    recurrence: 'weekly',
+    rotateAssignment: true,
+    imageUrl: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=800&q=80',
+    emoji: '🗑️',
+    tips: 'Add a quick sweep of the entryway for bonus sparkle.'
+  }
+]
+
+export const REWARD_IDEAS = [
+  {
+    id: 'reward-movie-host',
+    title: 'Family movie night host',
+    description: 'Pick the film, set the snack lineup, and choose everyone\'s coziest blankets for premiere night.',
+    cost: 45,
+    tag: 'Quality time',
+    imageUrl: 'https://images.unsplash.com/photo-1517604931442-7e0c8ed2963c?auto=format&fit=crop&w=800&q=80',
+    emoji: '🎬',
+    tips: 'Let the host design a homemade ticket for each seat.'
+  },
+  {
+    id: 'reward-breakfast-boss',
+    title: 'Breakfast boss',
+    description: 'Plan the morning menu—pancakes, smoothies, or parfaits—and be the chef\'s assistant while a grown-up handles the stove.',
+    cost: 35,
+    tag: 'Tasty treat',
+    imageUrl: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=800&q=80',
+    emoji: '🥞',
+    tips: 'Include a special playlist to dance to while cooking.'
+  },
+  {
+    id: 'reward-one-on-one',
+    title: 'One-on-one adventure',
+    description: 'Enjoy a solo date with a caregiver—think library visit, mini-golf, or grabbing hot cocoa downtown.',
+    cost: 60,
+    tag: 'Connection',
+    imageUrl: 'https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=800&q=80',
+    emoji: '💛',
+    tips: 'Let the winner plan the agenda from a pre-approved idea list.'
+  },
+  {
+    id: 'reward-late-bedtime',
+    title: '30-minute late bedtime pass',
+    description: 'Stay up past lights-out for bonus reading, drawing, or quiet game time with a caregiver.',
+    cost: 30,
+    tag: 'Privilege',
+    imageUrl: 'https://images.unsplash.com/photo-1530026405186-ed1f139313f8?auto=format&fit=crop&w=800&q=80',
+    emoji: '🌙',
+    tips: 'Pair it with twinkle lights or a cozy fort for extra magic.'
+  },
+  {
+    id: 'reward-build-day',
+    title: 'Big build day',
+    description: 'Spread out blocks or LEGOs and spend an afternoon creating a dream city together.',
+    cost: 50,
+    tag: 'Creative play',
+    imageUrl: 'https://images.unsplash.com/photo-1505685296765-3a2736de412f?auto=format&fit=crop&w=800&q=80',
+    emoji: '🏗️',
+    tips: 'Snap a photo of the finished masterpiece and add it to the family gallery.'
+  },
+  {
+    id: 'reward-community-gift',
+    title: 'Community kindness gift',
+    description: 'Use points to pick a charity donation or assemble a care kit for someone who needs a boost.',
+    cost: 70,
+    tag: 'Give back',
+    imageUrl: 'https://images.unsplash.com/photo-1461532257246-777de18cd58b?auto=format&fit=crop&w=800&q=80',
+    emoji: '🎁',
+    tips: 'Invite the child to write a quick note to include with the gift.'
+  }
+]


### PR DESCRIPTION
## Summary
- add an IdeaGallery component that presents curated cards with visuals and helper copy
- surface inspiration galleries in the settings creation hub so families can prefill chore or reward forms from an idea
- provide shared decks of chore and reward suggestions with family-friendly descriptions and imagery

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6d4c8b3f48326a5a82aef99ef3cf6