### PR TITLE
Adjust PWA install prompt placement

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import ChoresScreen from './pages/ChoresScreen.jsx'
 import RewardsScreen from './pages/RewardsScreen.jsx'
 import SettingsScreen from './pages/SettingsScreen.jsx'
 import { MediaImage } from './components/MediaImage.jsx'
+import { PwaInstallPrompt } from './components/PwaInstallPrompt.jsx'
 import { useFamboard } from './context/FamboardContext.jsx'
 import { isMemberAssignedToChore } from './utils/choreAssignments.js'
 import { ROUTES } from './constants/routes.js'
@@ -300,6 +301,7 @@ function Layout() {
       <footer className="border-t border-white/60 bg-white/70 py-6 text-center text-sm text-slate-500 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-400">
         Built with ❤️ for busy families. Works offline on your favorite tablet.
       </footer>
+      <PwaInstallPrompt />
     </div>
   )
 }

--- a/src/components/PwaInstallPrompt.jsx
+++ b/src/components/PwaInstallPrompt.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useFamboard } from '../context/FamboardContext.jsx'
+
+const SAFARI_IOS_MESSAGE = 'Install this app: Tap the Share icon → Add to Home Screen.'
+const DEFAULT_MESSAGE = 'Install this app for a better experience.'
+
+const getDisplayModeStandalone = () => {
+  if (typeof window === 'undefined') return true
+  if (window.matchMedia?.('(display-mode: standalone)')?.matches) {
+    return true
+  }
+  return Boolean(window.navigator?.standalone)
+}
+
+const isIosSafari = () => {
+  if (typeof navigator === 'undefined') return false
+  const userAgent = navigator.userAgent || ''
+  const isIos = /iphone|ipad|ipod/i.test(userAgent)
+  if (!isIos) return false
+  const isSafari = /safari/i.test(userAgent) && !/crios|fxios|opios|edgios/i.test(userAgent)
+  return isSafari
+}
+
+export function PwaInstallPrompt() {
+  const { state, isHydrated, dismissPwaInstallPrompt } = useFamboard()
+  const [isStandalone, setIsStandalone] = useState(() => getDisplayModeStandalone())
+  const [shouldRender, setShouldRender] = useState(false)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleChange = () => {
+      setIsStandalone(getDisplayModeStandalone())
+    }
+
+    const media = window.matchMedia?.('(display-mode: standalone)')
+    media?.addEventListener?.('change', handleChange)
+    media?.addListener?.(handleChange)
+    window.addEventListener('appinstalled', handleChange)
+
+    return () => {
+      media?.removeEventListener?.('change', handleChange)
+      media?.removeListener?.(handleChange)
+      window.removeEventListener('appinstalled', handleChange)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isHydrated) return undefined
+    if (isStandalone) return undefined
+    if (state.pwaInstallDismissedAt) return undefined
+    if (typeof window === 'undefined') return undefined
+
+    const timer = window.setTimeout(() => {
+      setShouldRender(true)
+    }, 2000)
+
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [isHydrated, isStandalone, state.pwaInstallDismissedAt])
+
+  useEffect(() => {
+    if (!shouldRender) return undefined
+    const frame = window.requestAnimationFrame(() => setIsVisible(true))
+    return () => {
+      window.cancelAnimationFrame(frame)
+    }
+  }, [shouldRender])
+
+  const message = useMemo(() => (isIosSafari() ? SAFARI_IOS_MESSAGE : DEFAULT_MESSAGE), [])
+
+  const dismiss = () => {
+    setIsVisible(false)
+    window.setTimeout(() => {
+      setShouldRender(false)
+      dismissPwaInstallPrompt()
+    }, 250)
+  }
+
+  if (!shouldRender) {
+    return null
+  }
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-5 z-50 flex justify-end px-4 sm:bottom-8 sm:px-6"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      <div
+        className={`pointer-events-auto flex max-w-md items-center gap-3 rounded-full bg-white/95 px-4 py-2 text-sm text-slate-700 shadow-lg shadow-slate-900/10 ring-1 ring-black/5 transition-all duration-300 ease-out dark:bg-slate-900/95 dark:text-slate-100 dark:ring-white/10 ${
+          isVisible ? 'translate-y-0 opacity-100' : 'translate-y-3 opacity-0'
+        }`}
+        role="status"
+        aria-live="polite"
+      >
+        <span className="text-base" aria-hidden>
+          📲
+        </span>
+        <p className="flex-1 text-left">{message}</p>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-slate-200/80 text-xs font-semibold text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-famboard-primary focus:ring-offset-1 dark:bg-slate-700/70 dark:text-slate-300 dark:hover:bg-slate-700"
+          aria-label="Dismiss install message"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default PwaInstallPrompt

--- a/src/context/FamboardContext.jsx
+++ b/src/context/FamboardContext.jsx
@@ -34,6 +34,7 @@ const withSchedule = (chore) => {
 const defaultData = {
   theme: 'light',
   activeView: 'family',
+  pwaInstallDismissedAt: null,
   mediaLibrary: [],
   settingsPin: null,
   familyMembers: [
@@ -242,6 +243,11 @@ export function FamboardProvider({ children }) {
         setState((prev) => ({
           ...prev,
           theme,
+        })),
+      dismissPwaInstallPrompt: () =>
+        setState((prev) => ({
+          ...prev,
+          pwaInstallDismissedAt: new Date().toISOString(),
         })),
       upsertMediaItem: (item) =>
         setState((prev) => {
@@ -591,6 +597,7 @@ export function FamboardProvider({ children }) {
           activeView: 'family',
           mediaLibrary: prev.mediaLibrary,
           settingsPin: prev.settingsPin,
+          pwaInstallDismissedAt: prev.pwaInstallDismissedAt,
         })),
     }),
     [state.theme],


### PR DESCRIPTION
## Summary
- move the floating PWA install banner toward the screen edge with safe-area padding
- keep the existing fade-in animation and styling while reducing interference with main content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7206cfaac8326baf2dafbbda0a270