### PR TITLE
Remove admin chore callout card

### DIFF
--- a/src/pages/ChoresScreen.jsx
+++ b/src/pages/ChoresScreen.jsx
@@ -197,23 +197,6 @@ export default function ChoresScreen() {
         </div>
       </section>
 
-      <section className="rounded-3xl bg-white/85 p-8 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="max-w-2xl space-y-2">
-            <h2 className="font-display text-3xl text-slate-800 dark:text-white">Need a new chore?</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              All chore creation and editing tools now live in the admin settings so grown-ups can manage the board in one place.
-            </p>
-          </div>
-          <Link
-            to={ROUTES.settings}
-            className="inline-flex items-center justify-center rounded-full bg-famboard-primary px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-famboard-dark focus:outline-none focus:ring-2 focus:ring-famboard-accent focus:ring-offset-2"
-          >
-            Go to admin settings
-          </Link>
-        </div>
-      </section>
-
       <section className="space-y-6">
         <div className="rounded-3xl bg-white/85 p-6 shadow-card ring-1 ring-white/30 backdrop-blur dark:bg-slate-900/75 dark:ring-slate-800">
           <ChoreCalendar


### PR DESCRIPTION
## Summary
- remove the “Need a new chore?” call-to-action from the chores screen so only the calendar and board remain

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e72520a2bc832695c0d11961a9232d