### PR TITLE
Fix media MIME filtering and normalize 404 redirect

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -10,9 +10,18 @@
         var pathname = window.location.pathname || '';
         var search = window.location.search || '';
         var hash = window.location.hash || '';
-        var relativePath = pathname.startsWith(base)
-          ? pathname.slice(base.length)
-          : pathname.replace(/^\//, '');
+        var trimmedBase = base.replace(/\/+$/, '');
+        var relativePath;
+
+        if (pathname === trimmedBase) {
+          relativePath = '';
+        } else if (pathname.startsWith(base)) {
+          relativePath = pathname.slice(base.length);
+        } else if (pathname.startsWith(trimmedBase + '/')) {
+          relativePath = pathname.slice(trimmedBase.length + 1);
+        } else {
+          relativePath = pathname.replace(/^\//, '');
+        }
         var redirect = relativePath + search + hash;
         try {
           sessionStorage.setItem('famboard-redirect', redirect);


### PR DESCRIPTION
## Summary
- allow image uploads without MIME metadata by using fallback extension checks and letting downstream validation handle them
- normalize the 404 redirect logic to avoid looping on /famboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7f5aa3acc83268f17bb3c52c438af